### PR TITLE
Preserve Sync Semantics, Tighten Async semantics

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 clojure 1.10.3.1058
-nodejs 12.22.1
+nodejs 16.4.0

--- a/Makefile
+++ b/Makefile
@@ -60,11 +60,11 @@ install: ci
 deploy: ci
 	clojure -T:build deploy
 
-# clean:
-# 	rm -f $(jar-file) $(pom-file)
-# 	rm -rf target/*
-# 	rm -rf cljs-test-runner-out
-# 	rm -f .make.*
+clean:
+	rm -f $(jar-file) $(pom-file)
+	rm -rf target/*
+	rm -rf cljs-test-runner-out
+	rm -f .make.*
 
 # Copied from: https://github.com/jeffsp/makefile_help/blob/master/Makefile
 # Tab nonesense resolved with help from StackOverflow... need a literal instead of the \t escape on MacOS

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,11 @@ test-clj: .make.test-clj
 test-cljs: .make.test-cljs
 
 .make.test-clj: deps.edn $(testfiles) $(srcfiles)
-	clojure -T:build test-clj
+	clojure -X:test:project/test-clj
 	touch .make.test-clj
 
 .make.test-cljs: deps.edn $(testfiles) $(srcfiles)
-	clojure -T:build test-cljs
+	clojure -M:test:project/test-cljs
 	touch .make.test-cljs
 
 lint: $(testfiles) $(srcfiles)

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Sometimes things go wrong, and the caterpillar eats something that didn't agree 
 
 ### The Spec
 
-Interceptors are represented as a map with the optional keys of `:enter`, `:leave`, and/or `:exit`.  None of the keys are required to be on an interceptor map, and if no truthy value for the key being checked is found on the interceptor map, the executor will continue its processing skipping over the interceptor for that stage.
+Interceptors are represented as a map with the optional keys of `:enter`, `:leave`, and `:error`.  None of the keys are required to be on an interceptor map, and if no truthy value for the key being checked is found on the interceptor map, the executor will continue its processing skipping over the interceptor for that stage.
 
 The idea of sticking to a map instead of a record is that if the interceptor is a map, consumers can attach any other data to the interceptor, which the executor will ignored instead of actively discarding when converting to a record, allowing the extra keys and values on the interceptor map to be accessible while it exists on the queue or the stack in the context.
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Sometimes things go wrong, and the caterpillar eats something that didn't agree 
 
 ### The Spec
 
-Interceptors are represented as a map with the optional keys of `:enter`, `:leave`, and `:error`.  None of the keys are required to be on an interceptor map, and if no truthy value for the key being checked is found on the interceptor map, the executor will continue its processing skipping over the interceptor for that stage.
+Interceptors are represented as a map with the optional keys of `:enter`, `:leave`, and `:error`.  None of the keys are required to be on an interceptor map, and if no truthy value for the key being checked is found on the interceptor map, the executor will continue its processing skipping over the interceptor for that stage.  A `:name` can also provided, in which case there are some affordances for tracing the interceptor execution by name.
 
 The idea of sticking to a map instead of a record is that if the interceptor is a map, consumers can attach any other data to the interceptor, which the executor will ignored instead of actively discarding when converting to a record, allowing the extra keys and values on the interceptor map to be accessible while it exists on the queue or the stack in the context.
 
@@ -95,7 +95,7 @@ The idea of sticking to a map instead of a record is that if the interceptor is 
 
 ##### Empty Queue of Interceptors
 
-The enter stage is considered completed when there are no more interceptors on the queue, and will start processing the interceptor chain from the stack.
+The enter stage is considered completed when there are no more interceptors on the queue; at this point papillon will start processing the interceptor chain from the accumulated stack.
 
 ##### Reduced Context
 
@@ -116,7 +116,7 @@ The interceptor stack will continue to be consumed through the `:error` stage un
 | `:lambda-toolshed.papillon/queue` | The queue of interceptors.  This gets initialized with the interceptors passed to `execute`, but can be managed if you know what you are doing.                                                                                                                                                                                                                                                                            |
 | `:lambda-toolshed.papillon/stack` | The stack of interceptors for traversing back through the chain of interceptors encountered.                                                                                                                                                                                                                                                                                                                               |
 | `:lambda-toolshed.papillon/error` | This key should have the error information associated with it.  This key signifies we are in an error state, and interceptors with `:error` key will be processed, either for them to clean up some state (open connections, etc.) or attempt to handle and resolve the error and return nicely.  A few examples might be: turn the error into 500 HTTP response; put original message and error onto an error queue; etc. |
-
+| `:lambda-toolshed.papillon/trace` | A vector at this key signals that interceptor chain execution should be traced by conj'ing tuples of the form `[itx-name stage]` onto the vector at every step. |
 
 ### Asynchronous Interceptors
 
@@ -132,19 +132,19 @@ After the executor "unwraps" the asynchronous result, if it finds an error in th
 
 #### ClojureScript and JavaScript interop
 
-If you are in ClojureScript, and are in Promise land (Editors Note: this is drastically different from The Promised Land, and the two should not be confused), you can import the namespace `lambda-toolshed.papillon.async` which will have a Promise implement `ReadPort` and turn the Promise into something that can be read in the same way as a channel.
+If you are in ClojureScript, and are in Promise land (Editor's Note: this is drastically different from The Promised Land, and the two should not be confused), you can import the namespace `lambda-toolshed.papillon.async` which will have a Promise implement `ReadPort` and turn the Promise into something that can be read in the same way as a channel.
 
 This is done by using `cljs.core.async.interop/p->c`, taking the `PromiseChannel` returned from that and turning it into a channel with the result being a single item on the channel.
 
 ## Examples and Other ways to extend usage
 
-### Interceptor Tracing/Timing
+### Interceptor Tricks
 
-Because the interceptor executor takes a sequence of interceptors to build the processing queue from, we can manipulate that before execution time as it is data.  In the example below, if we have tracing enabled, we interleave a tracing interceptor, could be a timing capture interceptor, with the standard interceptors we are expecting to process as part of the interceptor chain.
+Because the interceptor executor takes a sequence of interceptors to build the processing queue, we can manipulate it before and even during execution.  In the example below, if we have tracing enabled, we interleave a tracing interceptor, could be a timing capture interceptor, with the standard interceptors we are expecting to process as part of the interceptor chain.
 
 And example of this is found in [examples/example.cljc](./examples/example.cljc), and the `with-tracing` function that interleaves a tracing interceptor with a sequence of interceptors when in "debug" mode.
 
-There is also an example of another tracing system that is a bit more advanced in [examples/dynamic_tracing.cljc](examples/dynamic_tracing.cljc), which will wraps every following interceptor in the queue with tracing/timing functions, if the interceptor map is marked with meta-data.
+There is also an example of another tracing system that is a bit more advanced in [examples/dynamic_tracing.cljc](examples/dynamic_tracing.cljc), which wraps every following interceptor in the queue with tracing/timing functions, if the interceptor map is marked with meta-data.
 
 ### Nesting Interceptor Executions
 

--- a/deps.edn
+++ b/deps.edn
@@ -38,6 +38,11 @@
            :project/format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
                             :main-opts  ["-m" "cljfmt.main" "fix"]}
 
+           ;; Reference: https://github.com/liquidz/antq
+           ;; Example Usage: clj -M:outdated
+           :outdated {:extra-deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}
+                      :main-opts ["-m" "antq.core" "--skip=github-action"]}
+
            :project/format-check {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
                                   :main-opts  ["-m" "cljfmt.main" "check"]}
 

--- a/deps.edn
+++ b/deps.edn
@@ -5,18 +5,18 @@
  :aliases {:build {:deps {io.github.seancorfield/build-clj
                           {:git/tag "v0.6.4" :git/sha "c21cfde"}}
                    :ns-default build}
-           :dev {:extra-paths ["dev"]}
+           :dev {:extra-paths ["dev"]
+                 :jvm-opts ["-DENVIRONMENT=development"]}
            :test {:extra-paths ["test"]
-                  :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}
-                  :jvm-opts ["-DENVIRONMENT=test"]}
-
+                  :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}}
            :project/test-cljs {:main-opts ["-m" "cljs-test-runner.main"]
                                :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}
                                :jvm-opts ["-DENVIRONMENT=test"]}
-
-           :project/test-clj {:extra-deps {lambdaisland/kaocha {:mvn/version "1.73.1175"}}
-                              :exec-fn kaocha.runner/exec-fn
-                              :exec-args {}}
+           :project/test-clj {:extra-deps {io.github.cognitect-labs/test-runner
+                                           {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+                              :main-opts ["-m" "cognitect.test-runner"]
+                              :exec-fn cognitect.test-runner.api/test
+                              :jvm-opts ["-DENVIRONMENT=test"]}
 
            ;; for interactive test running
            :project/watch-test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.60.977"}}

--- a/deps.edn
+++ b/deps.edn
@@ -2,51 +2,50 @@
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}
         org.clojure/clojurescript {:mvn/version "1.10.773"}
         org.clojure/core.async {:mvn/version "1.3.618"}}
- :aliases
- {:build {:deps {io.github.seancorfield/build-clj
-                 {:git/tag "v0.6.4" :git/sha "c21cfde"}}
-          :ns-default build}
-  :dev {:extra-paths ["dev"]}
-  :test {:extra-paths ["test"]
-         :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}
-         :jvm-opts ["-DENVIRONMENT=test"]}
+ :aliases {:build {:deps {io.github.seancorfield/build-clj
+                          {:git/tag "v0.6.4" :git/sha "c21cfde"}}
+                   :ns-default build}
+           :dev {:extra-paths ["dev"]}
+           :test {:extra-paths ["test"]
+                  :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}
+                  :jvm-opts ["-DENVIRONMENT=test"]}
 
-  :project/test-cljs {:main-opts ["-m" "cljs-test-runner.main"]
-                      :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}
-                      :jvm-opts ["-DENVIRONMENT=test"]}
+           :project/test-cljs {:main-opts ["-m" "cljs-test-runner.main"]
+                               :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}
+                               :jvm-opts ["-DENVIRONMENT=test"]}
 
-  :project/test-clj {:extra-deps {lambdaisland/kaocha {:mvn/version "1.60.977"}}
-                     :exec-fn kaocha.runner/exec-fn
-                     :exec-args {}}
+           :project/test-clj {:extra-deps {lambdaisland/kaocha {:mvn/version "1.73.1175"}}
+                              :exec-fn kaocha.runner/exec-fn
+                              :exec-args {}}
 
-  ;; for interactive test running
-  :project/watch-test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.60.977"}}
-                       :exec-fn kaocha.runner/exec-fn
-                       :exec-args {:watch? true
-                                   :skip-meta :slow
-                                   :fail-fast? true}}
-  ;; --------------------------- Build/Deploy Tasks ----------------------------
-  ;; Bump the version by a patch and generate a corresponding pom file with the groupId "lambda-toolshed"
-  ;; $ clojure -M:project/pom patch -t IncrementType
-  :project/pom {:main-opts ["-m" "garamond.main" "--group-id" "lambda-toolshed"
-                            "--scm-url" "https://github.com/lambda-toolshed/papillon" "-p"]
-                ;; because we don't need the project's dependencies loaded -graph parses the deps.edn "out-of-band":
-                :replace-deps {com.workframe/garamond {:mvn/version "0.4.0"}}}
+           ;; for interactive test running
+           :project/watch-test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.60.977"}}
+                                :exec-fn kaocha.runner/exec-fn
+                                :exec-args {:watch? true
+                                            :skip-meta :slow
+                                            :fail-fast? true}}
+           ;; --------------------------- Build/Deploy Tasks ----------------------------
+           ;; Bump the version by a patch and generate a corresponding pom file with the groupId "lambda-toolshed"
+           ;; $ clojure -M:project/pom patch -t IncrementType
+           :project/pom {:main-opts ["-m" "garamond.main" "--group-id" "lambda-toolshed"
+                                     "--scm-url" "https://github.com/lambda-toolshed/papillon" "-p"]
+                         ;; because we don't need the project's dependencies loaded -graph parses the deps.edn "out-of-band":
+                         :replace-deps {com.workframe/garamond {:mvn/version "0.4.0"}}}
 
-  :lint/kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}
-               :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "--lint" "test" "--lint" "examples"]}
+           :lint/kondo {:extra-deps {clj-kondo/clj-kondo {:mvn/version "RELEASE"}}
+                        :main-opts  ["-m" "clj-kondo.main" "--lint" "src" "--lint" "test" "--lint" "examples"]}
 
-  :project/format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
-                   :main-opts  ["-m" "cljfmt.main" "fix"]}
+           :project/format {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
+                            :main-opts  ["-m" "cljfmt.main" "fix"]}
 
-  :project/format-check {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
-                         :main-opts  ["-m" "cljfmt.main" "check"]}
+           :project/format-check {:extra-deps {cljfmt/cljfmt {:mvn/version "0.8.0"}}
+                                  :main-opts  ["-m" "cljfmt.main" "check"]}
 
-  :project/cljs-nrepl {:main-opts ["-m" "nrepl.cmdline" "--middleware" "[\"cider.piggieback/wrap-cljs-repl\"]"]
-                       :extra-deps  {nrepl/nrepl  {:mvn/version "0.9.0"}
-                                     cider/piggieback {:mvn/version "0.5.3"}}}
+           :project/cljs-nrepl {:main-opts ["-m" "nrepl.cmdline" "--middleware" "[\"cider.piggieback/wrap-cljs-repl\"]"]
+                                :extra-deps  {nrepl/nrepl  {:mvn/version "0.9.0"}
+                                              cider/piggieback {:mvn/version "0.5.3"}}}
 
-  :project/nrepl {:main-opts ["-m" "nrepl.cmdline" "--middleware" "[\"cider.nrepl/cider-middleware\"]"]
-                  :extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}
-                               cider/cider-nrepl {:mvn/version "0.25.9"}}
-                  :jvm-opts ["-DENVIRONMENT=staging"]}}}
+           :project/nrepl {:main-opts ["-m" "nrepl.cmdline" "--middleware" "[\"cider.nrepl/cider-middleware\"]"]
+                           :extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}
+                                        cider/cider-nrepl {:mvn/version "0.25.9"}}
+                           :jvm-opts ["-DENVIRONMENT=staging"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -8,8 +8,7 @@
           :ns-default build}
   :dev {:extra-paths ["dev"]}
   :test {:extra-paths ["test"]
-         :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}
-                      io.github.cognitect-labs/test-runner {:git/tag "v0.5.0" :git/sha "48c3c67"}}
+         :extra-deps {org.clojure/test.check {:mvn/version "1.1.1"}}
          :jvm-opts ["-DENVIRONMENT=test"]}
 
   :project/test-cljs {:main-opts ["-m" "cljs-test-runner.main"]
@@ -51,4 +50,3 @@
                   :extra-deps {nrepl/nrepl {:mvn/version "0.9.0"}
                                cider/cider-nrepl {:mvn/version "0.25.9"}}
                   :jvm-opts ["-DENVIRONMENT=staging"]}}}
-

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,8 +1,7 @@
 (ns user
-  (:require [cljs.repl.node]
-            [cider.piggieback]))
+  (:require [cljs.repl.node]))
 
-(defn start-cljs
-  "Starts a CLJS repl by piggiebacking onto the cider nREPL"
-  []
-  (cider.piggieback/cljs-repl (cljs.repl.node/repl-env)))
+;; (defn start-cljs
+;;   "Starts a CLJS repl by piggiebacking onto the cider nREPL"
+;;   []
+;;   (cider.piggieback/cljs-repl (cljs.repl.node/repl-env)))

--- a/examples/lambda_toolshed/papillon/examples/condition_system.cljc
+++ b/examples/lambda_toolshed/papillon/examples/condition_system.cljc
@@ -147,9 +147,9 @@
 ;;     with the sequence in the http-request! method to
 ;;     see different error rates
 (go
-  (let [c (execute {:request-url "https://www.example.com"}
-                   [retry-http-ix
-                    request-ix])]
+  (let [c (execute [retry-http-ix
+                    request-ix]
+                   {:request-url "https://www.example.com"})]
     (clojure.pprint/pprint (<! c))))
 
 ;; Let's derive some keywords...
@@ -204,7 +204,7 @@
            [sig & sigs :as all-sigs] signal-hierarchy]
       (println "trying to find " sig " on interceptor " ix)
       (if-let [sig (first sigs)]
-        (if ix ; do we have an interceptor? or did we exhaust the stack?  
+        (if ix ; do we have an interceptor? or did we exhaust the stack?
           ;; yes we have an interceptor to check
           (if-let [f (sig ix)] ; can this interceptor handle the signal
             (apply f (concat [ctx] args)) ; yes? invoke it
@@ -250,7 +250,7 @@
 ;; ::http-request-failed key on the stack first
 ;; and then processes the stack looking for ::retry-request
 (go
-  (let [c (execute {:request-url "https://www.example.com"}
-                   [retry-request-ix
-                    advanced-request-signal-ix])]
+  (let [c (execute [retry-request-ix
+                    advanced-request-signal-ix]
+                   {:request-url "https://www.example.com"})]
     (clojure.pprint/pprint (<! c))))

--- a/examples/lambda_toolshed/papillon/examples/distributed_transaction.cljc
+++ b/examples/lambda_toolshed/papillon/examples/distributed_transaction.cljc
@@ -36,7 +36,7 @@
     (loop [[ix & ix-stack] stack
            [sig & sigs] signal-hierarchy]
       (if sig
-        (if ix ; do we have an interceptor? or did we exhaust the stack?  
+        (if ix ; do we have an interceptor? or did we exhaust the stack?
           ;; yes we have an interceptor to check
           (if-let [f (sig ix)] ; can this interceptor handle the signal
             (apply f (concat [c-out ctx] args)) ; yes? invoke it
@@ -198,7 +198,7 @@
                               :example.ditributed-transactions/send-sqs-message!])
                 (assoc :example.ditributed-transactions/transaction-record transaction-record
                        :example.ditributed-transactions/transaction-id id))]
-    (papillon/execute ctx (process-unreconciled-transaction-ixs))))
+    (papillon/execute (process-unreconciled-transaction-ixs) ctx)))
 
 ;; This also shows of spinning up multiple interceptor chains and executing
 ;; them in parallel and collecting the results into a single context result

--- a/examples/lambda_toolshed/papillon/examples/dynamic_tracing.cljc
+++ b/examples/lambda_toolshed/papillon/examples/dynamic_tracing.cljc
@@ -102,13 +102,14 @@
     {:supports-timing? true}))
 
 (go
-  (let [c (execute {} [instrument-timings-ix
-                       important-ix
-                       long-running-ix
-                       another-important-ix
-                       some-more-long-running-ix
-                       yet-another-important-ix
-                       varying-duration-ix])]
+  (let [c (execute [instrument-timings-ix
+                    important-ix
+                    long-running-ix
+                    another-important-ix
+                    some-more-long-running-ix
+                    yet-another-important-ix
+                    varying-duration-ix]
+                   {})]
     (println)
     (println "Results:")
     (clojure.pprint/pprint (<! c))))

--- a/examples/lambda_toolshed/papillon/examples/example.cljc
+++ b/examples/lambda_toolshed/papillon/examples/example.cljc
@@ -6,7 +6,6 @@
 
 ;; Synchronous interceptor with that only handles items
 ;; on enter, and adds a new key to the context
-;; :name key is currently optional and not used by Papillon
 (def one-ix
   {:name :one-ix
    :enter (fn [ctx]
@@ -14,9 +13,8 @@
 
 ;; Run an interceptor chain with one interceptor in it that is synchronous
 ;; and does not take an initial context to augment
-(go
-  (let [c (execute [one-ix])]
-    (clojure.pprint/pprint (<! c))))
+(let [c (execute [one-ix])]
+  (clojure.pprint/pprint c))
 
 ;; Synchronous interceptor with that only handles items
 ;; on enter, and updates an existing key in the context
@@ -27,39 +25,37 @@
 
 ;; Run an interceptor chain with one interceptor in it that is synchronous
 ;; and does not take an initial context to augment
-(go
-  (let [c (execute [one-ix
-                    double-number-ix])]
-    (clojure.pprint/pprint (<! c))))
+(let [c (execute [one-ix
+                  double-number-ix])]
+  (clojure.pprint/pprint c))
 
 ;; Define an interceptor that prints out a message for the different
 ;; stages that it handles, along with the context
-(defn make-trace-ix [enter-msg leave-msg error-msg]
-  {:name :make-trace-ix
+(defn make-logger-ix [enter-msg leave-msg error-msg]
+  {:name :logger-ix
    :enter (fn [ctx]
-            (println "make-trace-ix" enter-msg)
+            (println "logger-ix" enter-msg)
             (clojure.pprint/pprint ctx)
             ctx)
    :leave (fn [ctx]
-            (println "make-trace-ix" leave-msg)
+            (println "logger-ix" leave-msg)
             (clojure.pprint/pprint ctx)
             ctx)
    :error (fn [ctx]
-            (println "make-trace-ix" error-msg)
+            (println "logger-ix" error-msg)
             (clojure.pprint/pprint ctx)
             ctx)})
 
 ;; The execute takes a seq of interceptors for the queue, so
 ;; we can maniuplate the base sequence of interceptors before we
 ;; start execution
-(go
-  (let [c (execute (interleave (repeat (make-trace-ix "entering" "leaving" "errored ❌"))
-                               [one-ix
-                                double-number-ix
-                                double-number-ix]))]
-    (clojure.pprint/pprint (<! c))))
+(let [c (execute (interleave (repeat (make-logger-ix "entering" "leaving" "errored ❌"))
+                             [one-ix
+                              double-number-ix
+                              double-number-ix]))]
+  (clojure.pprint/pprint c))
 
-;; More complex tracing functionality, that shows that since the queue
+;; More complex debugging functionality, that shows that since the queue
 ;; and the stack are on the context, one can use that to their advantage
 (letfn [(describe-interceptor [ix] (or (:name ix) ix))
         (prettify-interceptors [ixs] (map describe-interceptor ixs))
@@ -68,38 +64,37 @@
         (prettify-ctx [ctx] (prettify-keys ctx
                                            :lambda-toolshed.papillon/queue prettify-queue
                                            :lambda-toolshed.papillon/stack prettify-interceptors))
-        (make-trace [stage] (fn [ctx]
-                              (clojure.pprint/pprint (str "Trace:: stage" stage))
-                              (clojure.pprint/pprint (prettify-ctx ctx))
-                              (println)
-                              ctx))]
-  (def trace-ix
+        (make-debugger [stage] (fn [ctx]
+                                 (clojure.pprint/pprint (str "Debug:: stage" stage))
+                                 (clojure.pprint/pprint (prettify-ctx ctx))
+                                 (println)
+                                 ctx))]
+  (def debug-ix
     {:name :trace-ix
-     :enter (make-trace :enter)
-     :leave (make-trace :leave)
-     :error (make-trace :error)}))
+     :enter (make-debugger :enter)
+     :leave (make-debugger :leave)
+     :error (make-debugger :error)}))
 
 ;; Are we in debug mode?
 ;;   (of course we are; we are playing with the examples.)
 ;;   real code could pull from env/config/dynamic var/request header, etc.
 (def debug true)
 
-;; A simplistic tracing helper to enable tracing when in debug mode
-(defn with-tracing
+;; A simplistic debugger helper to conditionally enable itx debugging
+(defn with-debugging
   [ixs]
   (if debug
-    (interleave (repeat trace-ix) ixs)
+    (interleave (repeat debug-ix) ixs)
     ixs))
 
 ;; Do some doubling, but use the pretty tracing to show how the
 ;; context is available to be munged for display, without updating
 ;; the context itself and killing the execution chain.
 ;; Persistant Data Structures FOR THE WIN!!
-(go
-  (let [c (execute (with-tracing [one-ix
+(let [c (execute (with-debugging [one-ix
                                   double-number-ix
                                   double-number-ix]))]
-    (clojure.pprint/pprint (<! c))))
+  (clojure.pprint/pprint c))
 
 ;; Asynchronous handler; returns a channel with the updated context inside it
 ;; Simple version where it is a go block
@@ -108,14 +103,14 @@
    :enter (fn [ctx]
             (go (update ctx :number #(* % 2))))})
 
-;; Do some asynchronous doubling, and use the pretty tracing to show how the
-;; context is available to be munged for display, without updating
+;; Do some asynchronous doubling, and use the pretty debugging to show how
+;; the context is available to be munged for display, without updating
 ;; the context itself and killing the execution chain.
 ;; Persistant Data Structures FOR THE WIN!!
 (go
-  (let [c (execute (with-tracing [one-ix
-                                  async-double-number-ix
-                                  async-double-number-ix]))]
+  (let [c (execute (with-debugging [one-ix
+                                    async-double-number-ix
+                                    async-double-number-ix]))]
     (clojure.pprint/pprint (<! c))))
 
 ;; Asynchronous handler; returns a channel with the updated context inside it
@@ -128,13 +123,13 @@
                 (>! c (update ctx :number #(* % %))))
               c))})
 
-;; Do some asynchronous doubling and squaring, with pretty tracing
+;; Do some asynchronous doubling and squaring, with pretty debugging
 (go
-  (let [c (execute (with-tracing [one-ix
-                                  async-double-number-ix
-                                  async-square-number-ix
-                                  async-double-number-ix
-                                  async-square-number-ix]))]
+  (let [c (execute (with-debugging [one-ix
+                                    async-double-number-ix
+                                    async-square-number-ix
+                                    async-double-number-ix
+                                    async-square-number-ix]))]
     (clojure.pprint/pprint (<! c))))
 
 ;; mark the context as reduced to stop processing
@@ -144,14 +139,13 @@
 
 ;; stop pretty much "immediately" after we get the number
 ;; in the context
-(go
-  (let [c (execute (with-tracing [one-ix
+(let [c (execute (with-debugging [one-ix
                                   reduced-ix
                                   async-double-number-ix
                                   async-square-number-ix
                                   async-double-number-ix
                                   async-square-number-ix]))]
-    (clojure.pprint/pprint (<! c))))
+  (clojure.pprint/pprint c))
 
 ;; "Something went wrong", this synchronous interceptor
 ;; throws an error
@@ -161,14 +155,13 @@
 
 ;; we bail on errors, and start processing the stack calling
 ;; the error handler on the interceptors
-(go
-  (let [c (execute (interleave (repeat trace-ix)
-                               [error-ix
-                                async-double-number-ix
-                                async-square-number-ix
-                                async-double-number-ix
-                                async-square-number-ix]))]
-    (clojure.pprint/pprint (<! c))))
+(let [c (execute (interleave (repeat debug-ix)
+                             [error-ix
+                              async-double-number-ix
+                              async-square-number-ix
+                              async-double-number-ix
+                              async-square-number-ix]))]
+  (clojure.pprint/pprint c))
 
 ;; Error handlers that would like to resolve the error
 (def resolving-error-handler-ix
@@ -179,11 +172,10 @@
 
 ;; Error handlers have to be registered before the interceptor that throws/returns
 ;; the error since things after it never get called.
-(go
-  (let [c (execute (interleave (repeat trace-ix)
-                               [resolving-error-handler-ix
-                                error-ix]))]
-    (clojure.pprint/pprint (<! c))))
+(let [c (execute (interleave (repeat debug-ix)
+                             [resolving-error-handler-ix
+                              error-ix]))]
+  (clojure.pprint/pprint c))
 
 ;; Error handlers don't have to resolve, they may only clean up resources
 ;; created in :enter
@@ -220,13 +212,12 @@
             (update ctx :number (fn [n] (if (= 1 n) "one" str))))})
 
 ;; Error handlers are allowed to not handle the error, but do other processing
-(go
-  (let [c (execute (interleave (repeat trace-ix)
-                               [one-ix
-                                resource-cleanup-error-handler-ix
-                                transforming-error-handler-ix
-                                error-ix]))]
-    (clojure.pprint/pprint (<! c))))
+(let [c (execute (interleave (repeat debug-ix)
+                             [one-ix
+                              resource-cleanup-error-handler-ix
+                              transforming-error-handler-ix
+                              error-ix]))]
+  (clojure.pprint/pprint c))
 
 ;; "Something went wrong", asynchronous interceptors return an error
 ;; since throwing in async mode loses the thrown error
@@ -237,13 +228,12 @@
 ;; error handlers work the same if the error is returned inside the channel
 ;; If an error is detected it gets added to the context passed to the
 ;; interceptor that resulted in the error
-(go
-  (let [c (execute (interleave (repeat trace-ix)
-                               [one-ix
-                                resource-cleanup-error-handler-ix
-                                transforming-error-handler-ix
-                                error-async-ix]))]
-    (clojure.pprint/pprint (<! c))))
+(go (let [c (execute (interleave (repeat debug-ix)
+                                 [one-ix
+                                  resource-cleanup-error-handler-ix
+                                  transforming-error-handler-ix
+                                  error-async-ix]))]
+      (clojure.pprint/pprint (<! c))))
 
 ;; Error handlers can be asynchronous as well...
 (def async-transforming-error-handler-ix
@@ -257,13 +247,12 @@
             (go (update ctx :number (fn [n] (if (= 1 n) "one" (str n))))))})
 
 ;; the chain works the same regardless if the error handler is sync or async
-(go
-  (let [c (execute (interleave (repeat trace-ix)
-                               [one-ix
-                                resource-cleanup-error-handler-ix
-                                async-transforming-error-handler-ix
-                                error-async-ix]))]
-    (clojure.pprint/pprint (<! c))))
+(let [c (execute (interleave (repeat debug-ix)
+                             [one-ix
+                              resource-cleanup-error-handler-ix
+                              async-transforming-error-handler-ix
+                              error-async-ix]))]
+  (clojure.pprint/pprint c))
 
 ;; a leave handler may also throw, and that starts running the error chain
 (def leave-throws-ix
@@ -273,7 +262,7 @@
 ;; the error handling chain works the same regardless if the error
 ;; handler is sync or async
 (go
-  (let [c (execute (interleave (repeat trace-ix)
+  (let [c (execute (interleave (repeat debug-ix)
                                [one-ix
                                 resource-cleanup-error-handler-ix
                                 async-transforming-error-handler-ix
@@ -291,7 +280,7 @@
 ;; the error handling chain works the same regardless if the error
 ;; handler is sync or async
 (go
-  (let [c (execute (interleave (repeat trace-ix)
+  (let [c (execute (interleave (repeat debug-ix)
                                [one-ix
                                 resource-cleanup-error-handler-ix
                                 async-transforming-error-handler-ix
@@ -310,7 +299,7 @@
 ;; the error original error is swallowed
 ;; be careful about how your error handlers behave
 (go
-  (let [c (execute (interleave (repeat trace-ix)
+  (let [c (execute (interleave (repeat debug-ix)
                                [one-ix
                                 resource-cleanup-error-handler-ix
                                 async-transforming-error-handler-ix
@@ -332,20 +321,20 @@
 
 ;; exits early when the starting number is 2
 (go
-  (let [c (execute {:number 2}
-                   (interleave (repeat trace-ix)
+  (let [c (execute (interleave (repeat debug-ix)
                                [async-square-number-ix
                                 done-when-even-ix
-                                double-number-ix]))]
+                                double-number-ix])
+                   {:number 2})]
     (clojure.pprint/pprint (<! c))))
 
 ;; continues through the whole chain when the starting number is 3
 (go
-  (let [c (execute {:number 3}
-                   (interleave (repeat trace-ix)
+  (let [c (execute (interleave (repeat debug-ix)
                                [async-square-number-ix
                                 done-when-even-ix
-                                double-number-ix]))]
+                                double-number-ix])
+                   {:number 3})]
     (clojure.pprint/pprint (<! c))))
 
 ;; Interceptors can also manipulate the queue
@@ -363,19 +352,19 @@
 ;; if tracing is still desired, it would be part of the client
 ;; code that enqueues more items to the context
 (go
-  (let [c (execute {:number 3}
-                   (interleave (repeat trace-ix)
+  (let [c (execute (interleave (repeat debug-ix)
                                [async-square-number-ix
-                                ensure-even-ix]))]
+                                ensure-even-ix])
+                   {:number 3})]
     (clojure.pprint/pprint (<! c))))
 
 ;; the sqaure of 2 is even, so we are done; nothing more to add
 ;; to the queue
 (go
-  (let [c (execute {:number 2}
-                   (interleave (repeat trace-ix)
+  (let [c (execute (interleave (repeat debug-ix)
                                [async-square-number-ix
-                                ensure-even-ix]))]
+                                ensure-even-ix])
+                   {:number 2})]
     (clojure.pprint/pprint (<! c))))
 
 ;; Interceptors can also manipulate the queue
@@ -393,17 +382,17 @@
 ;; if tracing is still desired, it would be part of the client
 ;; code that enqueues more items to the context
 (go
-  (let [c (execute {:number 3}
-                   (interleave (repeat trace-ix)
+  (let [c (execute (interleave (repeat debug-ix)
                                [async-square-number-ix
-                                ensure-even-with-tracing-ix]))]
+                                ensure-even-with-tracing-ix])
+                   {:number 3})]
     (clojure.pprint/pprint (<! c))))
 
 ;; the sqaure of 2 is even, so we are done; nothing more to add
 ;; to the queue
 (go
-  (let [c (execute {:number 2}
-                   (interleave (repeat trace-ix)
+  (let [c (execute (interleave (repeat debug-ix)
                                [async-square-number-ix
-                                ensure-even-with-tracing-ix]))]
+                                ensure-even-with-tracing-ix])
+                   {:number 2})]
     (clojure.pprint/pprint (<! c))))

--- a/src/lambda_toolshed/papillon.cljc
+++ b/src/lambda_toolshed/papillon.cljc
@@ -18,32 +18,34 @@
   (update-in ctx [::queue] into-queue ixs))
 
 (defn- error?
-  "Check if this is an exception."
+  "Is the given value `x` an exception?"
   [x]
   #?(:clj (instance? Throwable x)
      :cljs (instance? js/Error x)))
 
 (defn- async-catch
-  "Takes a value from a channel, and checks if it is an error type value.
-   If the result is an error type value add that to the previous context
-   under the `:lambda-toolshed.papillon/error` key and use that new result as the context.  Otherwise
-   use the value returned from the channel as the context."
-  [ctx res]
+  "Takes a value from the channel `c` and checks if it is an error type value.
+  If the result is an error type value then add that to the context `ctx` under
+  the `:lambda-toolshed.papillon/error` key and return it, otherwise return the
+  value unchanged."
+  [ctx c]
   (go
-    (let [x (<! res)]
+    (let [x (<! c)]
       (cond
         (nil? x) (assoc ctx ::error (ex-info "Context channel was closed." {::ctx ctx}))
         (error? x) (assoc ctx ::error x)
         :else x))))
 
 (defn- try-stage
-  "Try to invoke a stage on an interceptor with a context.
-   If the stage is not present, it means the interceptor does not support
-   this stage, so return the context and proceed to the next interceptor
-   in the chain.
+  "Try to invoke the stage function at the `stage` key of the interceptor `ix`
+  with the context `ctx` and return the result.  If there is no value at the
+  `stage` key the context is returned unchanged.
 
-   This also catches any errors that are raised (from synchronous calls)
-   and adds the error to the original context under the key `:lambda-toolshed.papillon/error`."
+  Errors synchronously thrown by the stage function are caught and added to
+  the original context under `:lambda-toolshed.papillon/error` key.
+
+  If the `:lambda-toolshed.papillon/trace` key is present then stage function
+  invocations are conj'd onto its value."
   [{trace ::trace :as ctx} ix stage]
   (let [ctx (if trace
               (update ctx ::trace conj [(or (:name ix) (-> ix meta :name)) stage])
@@ -59,20 +61,17 @@
       ctx)))
 
 (defn clear-queue
-  "Clear out the queue so that no further items in the enter chain are
-  processed.  Primarily used so one doesn't have to worry about
-  namespaced keywords."
+  "Remove the interceptor queue from the given context `ctx`, thus ensuring no
+  further processing of the `enter` chain is attempted."
   [ctx]
   (dissoc ctx ::queue))
 
 (defn- enter
-  "Runs the enter chain.  If the key :lambda-toolshed.papillon/error is present in the context
-  we stop the `enter` chain and proceed to the next stage.  If the
-  context is reduced, we unreduce the context and proceed to the next
-  stage.  Reducing the context allows us to have an early return
-  mechanism without causing users to resort to throwing errors and
-  then immediately handling them, or having to worry about clearing
-  out the queue themselves.
+  "Run the queued enter chain in the given context `ctx`.  If the
+  `:lambda-toolshed.papillon/error` key is present in `ctx` then clear the queue
+  (thus terminating the `enter` chain) and start processing the `:error` chain.
+  If `ctx` is reduced (per `clojure.core/reduced?`) an early return is inferred
+  and the unreduced `ctx` is used to start processing the `:leave` chain.
 
   `enter` also 'collapses' nested async calls by recurisvely calling
   itself with the value taken from the channel to ensure that if a
@@ -96,19 +95,13 @@
                            (try-stage ix :enter))))))))
 
 (defn- leave
-  "Runs the leave and error chain.  `leave` will run the `:lambda-toolshed.papillon/error`
-  key function in the interceptor if there is an `:lambda-toolshed.papillon/error` in the context.
+  "Runs the stacked `:leave` chain or `:error` chain in the given context `ctx`.
+  if there is a value at the `:lambda-toolshed.papillon/error` key in `ctx` then
+  the `:error` chain is run, otherwise the `:leave` chain is run.
 
-  If there is no `:lambda-toolshed.papillon/error` key in the context, it will run the function
-  under the `:leave` key in the interceptor.
-
-  If your interceptor had decided to handle the error in the context, it
-  should remove the `:lambda-toolshed.papillon/error` key from the context, and allow any remaining
-  interceptors to run their `:leave` functions, unless one of them throws
-  an error.
-
-  If the function under the `:enter` key 'opened' a resource, you will
-  want to ensure it is closed in both the `:lambda-toolshed.papillon/error` and `:leave` case, as either path may be taken on the way back up the interceptor chain."
+  You should remove the `:lambda-toolshed.papillon/error` key from the returned
+  context if you handle the error.  This will stop processing the `:error` chain
+  and start processing the `:leave` chain in the stack of interceptors."
   [ctx]
   (if (satisfies? ReadPort ctx)
     (go (leave (<! ctx)))
@@ -123,10 +116,8 @@
                      (try-stage ix stage))))))))
 
 (defn- init-ctx
-  "Sets up the context with the queue key and the stack key.
-
-  The queue is for the forward processing of items, and the stack
-  is what is used to trace backwards through the interceptor stack"
+  "Inialize the given context `ctx` with the necessary data structures to
+  process the interceptor chain `ixs`."
   [ctx ixs]
   (assoc (enqueue ctx ixs)
          ::stack []))
@@ -138,8 +129,8 @@
     result))
 
 (defn- present-async
-  [res]
-  (go-loop [ctx res]
+  [result]
+  (go-loop [ctx result]
     (if (satisfies? ReadPort ctx)
       (recur (<! ctx))
       (if-let [error (::error ctx)]
@@ -153,23 +144,22 @@
       (vary-meta ix update :name (fnil identity (fmt "itx%02d" i))))))
 
 (defn execute
-  "Executes the interceptor call chain as a queue.
+  "Execute the interceptor chain `ixs` with the given initial context `ctx`.
 
-  It will run foward through the chain calling the function
-  associated to the `:enter` key where that where that function
-  exists, while adding the interceptor to the history of
-  interceptors seen, so when the :enter chain is
-  finished, it can run backwards through the history
-  (reverse order) to apply the functions associated to `:leave`,
-  or `:error`, as determined by the `:lambda-toolshed.papillon/error` key
-  on the context.
+  Run foward through the chain calling the functions associated with the
+  `:enter` key (where it exists), while accumulating a stack of interceptors
+  seen.
 
-  `execute` takes any map as an initial context, and will associate
-  the queue and stack into the context to start processing.  If no
-  context is provided an empty map is used.  Note: The behavior of
-  starting with an initial context that contains the key
-  `:lambda-toolshed.papillon/error` is left unspecified and may be subject to
-  change.
+  When the `:enter` chain is exhausted, run the accumulated stack in reverse
+  order invoking the function at the `:leave` or `:error` key based on the
+  `:lambda-toolshed.papillon/error` key of the context.
+
+  The initial context `ctx` is augmented with the necessary housekeeping data
+  structures before processing the chain.  If no context is provided an empty
+  map is used.
+
+  Note: Starting with an initial context that contains the key
+  `:lambda-toolshed.papillon/error` is undefined and may change.
 
   Executing the interceptor chain can complete synchronously or asynchronously.
   If any interceptor function (enter, leave or error) completes asynchronously,

--- a/src/lambda_toolshed/papillon.cljc
+++ b/src/lambda_toolshed/papillon.cljc
@@ -57,7 +57,7 @@
     (try
       (let [res (f ctx)]
         (if (satisfies? ReadPort res)
-          (go (<! (async-catch ctx res)))
+          (async-catch ctx res)
           res))
       (catch #?(:clj Throwable :cljs :default) err
         (assoc ctx :lambda-toolshed.papillon/error err)))

--- a/src/lambda_toolshed/papillon.cljc
+++ b/src/lambda_toolshed/papillon.cljc
@@ -40,9 +40,10 @@
   [ctx res]
   (go
     (let [x (<! res)]
-      (if (error? x)
-        (assoc ctx :lambda-toolshed.papillon/error x)
-        x))))
+      (cond
+        (nil? x) (assoc ctx :lambda-toolshed.papillon/error (ex-info "Context channel was closed." {::ctx ctx}))
+        (error? x) (assoc ctx :lambda-toolshed.papillon/error x)
+        :else x))))
 
 (defn- try-stage
   "Try to invoke a stage on an interceptor with a context.

--- a/src/lambda_toolshed/papillon.cljc
+++ b/src/lambda_toolshed/papillon.cljc
@@ -167,7 +167,7 @@
   2. (sync) the chain execution result, or a thrown exception (when not handled
      by the chain)."
   ([ixs]
-   (execute {} ixs))
+   (execute ixs {}))
   ([ixs ctx]
    (let [ixs (map-indexed namer ixs)
          ctx (init-ctx ctx ixs)

--- a/src/lambda_toolshed/papillon.cljc
+++ b/src/lambda_toolshed/papillon.cljc
@@ -174,8 +174,7 @@
      by the chain)."
   ([ixs]
    (execute {} ixs))
-  ;; TODO: swap order of these parameters to allow efficient partial execution.
-  ([ctx ixs]
+  ([ixs ctx]
    (let [ixs (map-indexed namer ixs)
          ctx (init-ctx ctx ixs)
          result (leave (enter ctx))]

--- a/test/lambda_toolshed/papillon_test.cljc
+++ b/test/lambda_toolshed/papillon_test.cljc
@@ -278,15 +278,16 @@
                (js/Promise.resolve
                 (update-in ctx [(keyword (str (name :enter) "-invocation-counts"))] inc)))}))
 
-(deftest allows-for-promise-return-values
+(do
   #?(:cljs
-     (go-test
-      (let [ixs [track-enter-promise-ix]
-            c (ix/execute invocation-tracking-ctx ixs)
-            [res p] (alts! [c (async/timeout 10)])]
-        (is (= p c))
-        (is (empty? (:lambda-toolshed.papillon/queue res)))
-        (is (empty? (:lambda-toolshed.papillon/stack res)))
-        (is (= 1 (:enter-invocation-counts res)))
-        (is (= 0 (:leave-invocation-counts res)))
-        (is (= 0 (:error-invocation-counts res)))))))
+     (deftest allows-for-promise-return-values
+       (go-test
+        (let [ixs [track-enter-promise-ix]
+              c (ix/execute invocation-tracking-ctx ixs)
+              [res p] (alts! [c (async/timeout 10)])]
+          (is (= p c))
+          (is (empty? (:lambda-toolshed.papillon/queue res)))
+          (is (empty? (:lambda-toolshed.papillon/stack res)))
+          (is (= 1 (:enter-invocation-counts res)))
+          (is (= 0 (:leave-invocation-counts res)))
+          (is (= 0 (:error-invocation-counts res))))))))

--- a/test/lambda_toolshed/papillon_test.cljc
+++ b/test/lambda_toolshed/papillon_test.cljc
@@ -3,7 +3,7 @@
    [clojure.core.async :as async :refer [alts! go]]
    [clojure.test :refer [deftest is testing]]
    [lambda-toolshed.papillon :as ix]
-   [lambda-toolshed.test-utils :refer [go-test] :include-macros true]))
+   [lambda-toolshed.test-utils :refer [go-test runt! runt-fn!] :include-macros true]))
 
 (def ^:private invocation-tracking-ctx
   {:enter-invocation-counts 0
@@ -38,9 +38,16 @@
             (go
               (track-invocation :leave ctx)))})
 
+(def ^:private track-ix (merge track-enter-ix track-leave-ix track-error-ix))
+
 (defn- throws-ix
   [stage ex]
   {stage (fn [_ctx] (throw ex))})
+
+(def ^:private capture-ix
+  {:error (fn [{error :lambda-toolshed.papillon/error :as ctx}] (-> ctx
+                                                                    (dissoc :lambda-toolshed.papillon/error)
+                                                                    (assoc ::error error)))})
 
 (defn- async-returns-error-ix
   [stage ex]
@@ -67,20 +74,34 @@
           ctx (ix/clear-queue (ix/enqueue {} ixs))]
       (is (not (contains? ctx :lambda-toolshed.papillon/queue))))))
 
+(def empty-context {:lambda-toolshed.papillon/queue #?(:clj clojure.lang.PersistentQueue/EMPTY
+                                                       :cljs cljs.core/PersistentQueue.EMPTY)
+                    :lambda-toolshed.papillon/stack []})
+
+(defn ->async
+  [itx]
+  "Convert the synchronous interceptor `itx` to the async equivalent"
+  (-> itx
+      (update :enter #(when % (fn [ctx] (async/go (% ctx)))))
+      (update :leave #(when % (fn [ctx] (async/go (% ctx)))))
+      (update :error #(when % (fn [ctx] (async/go (% ctx)))))))
+
 (deftest allows-for-empty-chain-of-interceptors
-  (go-test
-   (let [c (ix/execute {} [])
-         [res p] (alts! [c (async/timeout 10)])]
-     (is (= p c))
-     (is (empty? (:lambda-toolshed.papillon/queue res)))
-     (is (empty? (:lambda-toolshed.papillon/stack res))))))
+  (is (= empty-context (ix/execute {} []))))
 
 (deftest allows-for-interceptor-chain-of-only-enters
+  (let [ixs [track-enter-ix]
+        res (ix/execute invocation-tracking-ctx ixs)]
+    (is (empty? (:lambda-toolshed.papillon/queue res)))
+    (is (empty? (:lambda-toolshed.papillon/stack res)))
+    (is (= 1 (:enter-invocation-counts res)))
+    (is (= 0 (:leave-invocation-counts res)))
+    (is (= 0 (:error-invocation-counts res))))
   (go-test
-   (let [ixs [track-enter-ix]
-         c (ix/execute invocation-tracking-ctx ixs)
-         [res p] (alts! [c (async/timeout 10)])]
-     (is (= p c))
+   (let [ixs [(->async track-enter-ix)]
+         [res _] (async/alts! [(ix/execute invocation-tracking-ctx ixs)
+                               (async/timeout 10)])]
+     (is (map? res))
      (is (empty? (:lambda-toolshed.papillon/queue res)))
      (is (empty? (:lambda-toolshed.papillon/stack res)))
      (is (= 1 (:enter-invocation-counts res)))
@@ -88,11 +109,18 @@
      (is (= 0 (:error-invocation-counts res))))))
 
 (deftest allows-for-interceptor-chain-of-only-leaves
+  (let [ixs [track-leave-ix]
+        res (ix/execute invocation-tracking-ctx ixs)]
+    (is (empty? (:lambda-toolshed.papillon/queue res)))
+    (is (empty? (:lambda-toolshed.papillon/stack res)))
+    (is (= 0 (:enter-invocation-counts res)))
+    (is (= 1 (:leave-invocation-counts res)))
+    (is (= 0 (:error-invocation-counts res))))
   (go-test
-   (let [ixs [track-leave-ix]
-         c (ix/execute invocation-tracking-ctx ixs)
-         [res p] (alts! [c (async/timeout 10)])]
-     (is (= p c))
+   (let [ixs [(->async track-leave-ix)]
+         [res _] (async/alts! [(ix/execute invocation-tracking-ctx ixs)
+                               (async/timeout 10)])]
+     (is (map? res))
      (is (empty? (:lambda-toolshed.papillon/queue res)))
      (is (empty? (:lambda-toolshed.papillon/stack res)))
      (is (= 0 (:enter-invocation-counts res)))
@@ -100,192 +128,139 @@
      (is (= 0 (:error-invocation-counts res))))))
 
 (deftest allows-for-interceptor-chain-of-only-errors
+  (let [ixs [track-error-ix]
+        res (ix/execute invocation-tracking-ctx ixs)]
+    (is (empty? (:lambda-toolshed.papillon/queue res)))
+    (is (empty? (:lambda-toolshed.papillon/stack res)))
+    (is (= 0 (:enter-invocation-counts res)))
+    (is (= 0 (:leave-invocation-counts res)))
+    (is (= 0 (:error-invocation-counts res))))
   (go-test
-   (let [ixs [track-error-ix]
-         c (ix/execute invocation-tracking-ctx ixs)
-         [res p] (alts! [c (async/timeout 10)])]
-     (is (= p c))
-     (is (empty? (:lambda-toolshed.papillon/queue res)))
-     (is (empty? (:lambda-toolshed.papillon/stack res)))
-     (is (= 0 (:enter-invocation-counts res)))
-     (is (= 0 (:leave-invocation-counts res)))
-     (is (= 0 (:error-invocation-counts res))))))
+   "Nothing to be done; chain can't start async processing with only error fns"))
 
 (deftest error-stage-is-never-invoked-if-no-error-has-been-thrown
+  (let [ixs (repeat 2 track-ix)
+        res (ix/execute invocation-tracking-ctx ixs)]
+    (is (map? res))
+    (is (empty? (:lambda-toolshed.papillon/queue res)))
+    (is (empty? (:lambda-toolshed.papillon/stack res)))
+    (is (= 0 (:error-invocation-counts res))))
   (go-test
-   (let [ixs (repeat 2 (merge track-enter-ix
-                              track-error-ix))
-         c (ix/execute invocation-tracking-ctx ixs)
-         [res p] (alts! [c (async/timeout 10)])]
-     (is (= p c))
+   (let [ixs (repeat 2 (->async track-ix))
+         [res _] (async/alts! [(ix/execute invocation-tracking-ctx ixs)
+                               (async/timeout 10)])]
+     (is (map? res))
      (is (empty? (:lambda-toolshed.papillon/queue res)))
      (is (empty? (:lambda-toolshed.papillon/stack res)))
      (is (= 0 (:error-invocation-counts res))))))
 
-(deftest error-chain-is-invoked-when-enter-throws-an-exception
+(deftest exception-semantics-are-preserved
+  (let [the-exception (ex-info "the exception" {})
+        ixs [(throws-ix :enter the-exception)]]
+    (is (thrown-with-msg?
+         #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
+         #"the exception"
+         (ix/execute invocation-tracking-ctx ixs))))
   (go-test
    (let [the-exception (ex-info "the exception" {})
-         ixs [track-error-ix
-              track-error-ix
-              (merge (throws-ix :enter the-exception)
-                     track-error-ix)]
-         c (ix/execute invocation-tracking-ctx ixs)
-         [res p] (alts! [c (async/timeout 10)])]
-     (is (= p c))
-     (is (= the-exception (:lambda-toolshed.papillon/error res)))
+         ixs [(->async {:enter identity}) ; transition to async
+              (throws-ix :enter the-exception)]
+         [res _] (async/alts! [(ix/execute invocation-tracking-ctx ixs)
+                               (async/timeout 10)])]
+     (is (= the-exception res)))))
+
+(deftest error-chain-is-invoked-when-enter-throws-an-exception
+  (let [the-exception (ex-info "the exception" {})
+        ixs [capture-ix
+             track-error-ix
+             track-error-ix
+             (merge (throws-ix :enter the-exception)
+                    track-error-ix)]
+        res (ix/execute invocation-tracking-ctx ixs)]
+    (is (= the-exception (::error res)))
+    (is (= 3 (:error-invocation-counts res))))
+  (go-test
+   (let [the-exception (ex-info "the exception" {})
+         ixs [(->async capture-ix)
+              (->async track-error-ix)
+              (->async track-error-ix)
+              (->async track-error-ix)
+              (throws-ix :enter the-exception)]
+         [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
+                         (async/timeout 10)])]
+     (is (map? res))
+     (is (= the-exception (::error res)))
      (is (= 3 (:error-invocation-counts res))))))
 
 (deftest error-chain-is-invoked-when-leave-throws-an-exception
+  (let [the-exception (ex-info "the exception" {})
+        ixs [capture-ix
+             (merge (throws-ix :leave the-exception)
+                    track-error-ix)]
+        res (ix/execute invocation-tracking-ctx ixs)]
+    (is (= the-exception (::error res)))
+    (is (zero? (:error-invocation-counts res))))
   (go-test
    (let [the-exception (ex-info "the exception" {})
-         ixs [track-error-ix
-              track-error-ix
+         ixs [(->async capture-ix)
               (merge (throws-ix :leave the-exception)
                      track-error-ix)]
-         c (ix/execute invocation-tracking-ctx ixs)
-         [res p] (alts! [c (async/timeout 10)])]
-     (is (= p c))
-     (is (= the-exception (:lambda-toolshed.papillon/error res)))
-     (is (= 2 (:error-invocation-counts res))))))
+         [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
+                         (async/timeout 10)])]
+     (is (map? res))
+     (is (= the-exception (::error res)))
+     (is (zero? (:error-invocation-counts res))))))
 
-(deftest leave-chain-is-reinvoked-when-an-error-processor-removed-the-error-key
+(deftest leave-chain-is-resumed-when-error-processor-removes-error-key
+  (let [the-exception (ex-info "the exception" {})
+        ixs [(merge track-leave-ix track-error-ix)
+             capture-ix
+             (merge (throws-ix :leave the-exception)
+                    track-error-ix)]
+        res (ix/execute invocation-tracking-ctx ixs)]
+    (is (not (contains? res :lambda-toolshed.papillon/error)))
+    (is (zero? (:error-invocation-counts res)))
+    (is (= 1 (:leave-invocation-counts res))))
   (go-test
    (let [the-exception (ex-info "the exception" {})
-         ixs [track-leave-ix
-              track-leave-ix
-              {:error (fn [ctx]
-                        (-> ctx
-                            (#(track-invocation :error %))
-                            (dissoc :lambda-toolshed.papillon/error)))}
+         ixs [(->async (merge track-leave-ix track-error-ix))
+              (->async capture-ix)
               (merge (throws-ix :leave the-exception)
                      track-error-ix)]
-         c (ix/execute invocation-tracking-ctx ixs)
-         [res p] (alts! [c (async/timeout 10)])]
-     (is (= p c))
+         [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
+                         (async/timeout 10)])]
+     (is (map? res))
      (is (not (contains? res :lambda-toolshed.papillon/error)))
-     (is (= 1 (:error-invocation-counts res)))
-     (is (= 2 (:leave-invocation-counts res))))))
+     (is (zero? (:error-invocation-counts res)))
+     (is (= 1 (:leave-invocation-counts res))))))
 
 (deftest reduced-context-stops-enter-chain-processing
+  (let [ixs [(merge track-enter-ix track-leave-ix)
+             {:enter reduced}
+             track-enter-ix]
+        res (ix/execute invocation-tracking-ctx ixs)]
+    (is (= 1 (:enter-invocation-counts res)))
+    (is (= 1 (:leave-invocation-counts res))))
   (go-test
-   (let [post-reduced-ix-calls (atom [])
-         starting-ctx {:enter-invocation-counts 0
-                       :leave-invocation-counts 0
-                       :error-invocation-counts 0}
-         ixs [(merge track-enter-ix
-                     track-leave-ix)
-              (merge {:enter reduced}
-                     track-leave-ix)
-              {:enter (fn [ctx] (swap! post-reduced-ix-calls conj ctx))
-               :leave (fn [_] (throw (ex-info "should not process leaves of interceptors in the queue after a reduced value" {})))}]
-         c (ix/execute starting-ctx ixs)
-         [res p] (alts! [c (async/timeout 10)])]
-     (is (= p c))
-     (is (= [] @post-reduced-ix-calls))
+   (let [ixs [(->async (merge track-enter-ix track-leave-ix))
+              (->async {:enter reduced})
+              (->async track-enter-ix)]
+         [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
+                         (async/timeout 10)])]
+     (is (map? res))
      (is (= 1 (:enter-invocation-counts res)))
-     (is (= 2 (:leave-invocation-counts res))))))
-
-(deftest allows-for-interceptor-chain-of-only-async-enters
-  (go-test
-   (let [ixs [track-enter-async-ix]
-         c (ix/execute invocation-tracking-ctx ixs)
-         timeout (async/timeout 100)
-         [res p] (alts! [c timeout])]
-     (is (= p c))
-     (is (empty? (:lambda-toolshed.papillon/queue res)))
-     (is (empty? (:lambda-toolshed.papillon/stack res)))
-     (is (= 1 (:enter-invocation-counts res)))
-     (is (= 0 (:leave-invocation-counts res)))
-     (is (= 0 (:error-invocation-counts res))))))
-
-(deftest allows-for-interceptor-chain-of-only-async-leaves
-  (go-test
-   (let [ixs [track-leave-async-ix]
-         c (ix/execute invocation-tracking-ctx ixs)
-         timeout (async/timeout 100)
-         [res p] (alts! [c timeout])]
-     (is (= p c))
-     (is (empty? (:lambda-toolshed.papillon/queue res)))
-     (is (empty? (:lambda-toolshed.papillon/stack res)))
-     (is (= 0 (:enter-invocation-counts res)))
-     (is (= 1 (:leave-invocation-counts res)))
-     (is (= 0 (:error-invocation-counts res))))))
-
-(deftest allows-for-interceptor-chain-of-only-aysnc-errors
-  (go-test
-   (let [ixs [track-error-async-ix]
-         c (ix/execute invocation-tracking-ctx ixs)
-         timeout (async/timeout 100)
-         [res p] (alts! [c timeout])]
-     (is (= p c))
-     (is (empty? (:lambda-toolshed.papillon/queue res)))
-     (is (empty? (:lambda-toolshed.papillon/stack res)))
-     (is (= 0 (:enter-invocation-counts res)))
-     (is (= 0 (:leave-invocation-counts res)))
-     (is (= 0 (:error-invocation-counts res)) "Error chain was invoked with no error thrown"))))
-
-(deftest error-chain-is-invoked-when-async-enter-returns-an-exception
-  (go-test
-   (let [the-exception (ex-info "the exception" {})
-         ixs [track-error-ix
-              track-error-ix
-              (merge (async-returns-error-ix :enter the-exception)
-                     track-error-ix)]
-         c (ix/execute invocation-tracking-ctx ixs)
-         timeout (async/timeout 100)
-         [res p] (alts! [c timeout])]
-     (is (= p c))
-     (is (= the-exception (:lambda-toolshed.papillon/error res)))
-     (is (= 3 (:error-invocation-counts res))))))
-
-(deftest error-chain-is-invoked-when-async-leave-returns-an-exception
-  (go-test
-   (let [the-exception (ex-info "the exception" {})
-         ixs [track-error-ix
-              track-error-ix
-              (merge (async-returns-error-ix :leave the-exception)
-                     track-error-ix)]
-         c (ix/execute invocation-tracking-ctx ixs)
-         timeout (async/timeout 100)
-         [res p] (alts! [c timeout])]
-     (is (= p c))
-     (is (= the-exception (:lambda-toolshed.papillon/error res)))
-     (is (= 2 (:error-invocation-counts res))))))
-
-(deftest leave-chain-is-reinvoked-when-an-error-processor-removed-the-error-key-in-async-error-handler
-  (go-test
-   (let [the-exception (ex-info "the exception" {})
-         ixs [track-leave-ix
-              track-leave-ix
-              {:error (fn [ctx]
-                        (go
-                          (-> ctx
-                              (#(track-invocation :error %))
-                              (dissoc :lambda-toolshed.papillon/error))))}
-              (merge (async-returns-error-ix :leave the-exception)
-                     track-error-ix)]
-         c (ix/execute invocation-tracking-ctx ixs)
-         timeout (async/timeout 100)
-         [res p] (alts! [c timeout])]
-     (is (= p c))
-     (is (not (contains? res :lambda-toolshed.papillon/error)))
-     (is (= 1 (:error-invocation-counts res)))
-     (is (= 2 (:leave-invocation-counts res))))))
-
-#?(:cljs
-   (def ^:private track-enter-promise-ix
-     {:enter (fn [ctx]
-               (js/Promise.resolve
-                (update-in ctx [(keyword (str (name :enter) "-invocation-counts"))] inc)))}))
+     (is (= 1 (:leave-invocation-counts res))))))
 
 (do
   #?(:cljs
      (deftest allows-for-promise-return-values
        (go-test
-        (let [ixs [track-enter-promise-ix]
-              c (ix/execute invocation-tracking-ctx ixs)
-              [res p] (alts! [c (async/timeout 10)])]
-          (is (= p c))
+        (let [ixs [{:enter (fn [ctx]
+                             (js/Promise.resolve
+                              (update-in ctx [(keyword (str (name :enter) "-invocation-counts"))] inc)))}]
+              [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
+                              (async/timeout 10)])]
+          (is (map? res))
           (is (empty? (:lambda-toolshed.papillon/queue res)))
           (is (empty? (:lambda-toolshed.papillon/stack res)))
           (is (= 1 (:enter-invocation-counts res)))

--- a/test/lambda_toolshed/papillon_test.cljc
+++ b/test/lambda_toolshed/papillon_test.cljc
@@ -5,42 +5,22 @@
    [lambda-toolshed.papillon :as ix]
    [lambda-toolshed.test-utils :refer [go-test runt! runt-fn!] :include-macros true]))
 
-(def ^:private invocation-tracking-ctx
-  {:enter-invocation-counts 0
-   :leave-invocation-counts 0
-   :error-invocation-counts 0})
-
-(defn- track-invocation
+(defn- track-ix
   [stage ctx]
-  (update-in ctx [(keyword (str (name stage) "-invocation-counts"))] inc))
+  (update-in ctx [:calls stage] (fnil inc 0)))
 
 (def ^:private track-error-ix
-  {:error (partial track-invocation :error)})
-
-(def ^:private track-error-async-ix
-  {:error (fn [ctx]
-            (go
-              (track-invocation :error ctx)))})
+  {:error (partial track-ix :error)})
 
 (def ^:private track-enter-ix
-  {:enter (partial track-invocation :enter)})
-
-(def ^:private track-enter-async-ix
-  {:enter (fn [ctx]
-            (let [new-ctx (track-invocation :enter ctx)]
-              (go new-ctx)))})
+  {:enter (partial track-ix :enter)})
 
 (def ^:private track-leave-ix
-  {:leave (partial track-invocation :leave)})
+  {:leave (partial track-ix :leave)})
 
-(def ^:private track-leave-async-ix
-  {:leave (fn [ctx]
-            (go
-              (track-invocation :leave ctx)))})
+(def ^:private track-all-ix (merge track-enter-ix track-leave-ix track-error-ix))
 
-(def ^:private track-ix (merge track-enter-ix track-leave-ix track-error-ix))
-
-(defn- throws-ix
+(defn- throw-ix
   [stage ex]
   {stage (fn [_ctx] (throw ex))})
 
@@ -49,9 +29,13 @@
                                                                     (dissoc :lambda-toolshed.papillon/error)
                                                                     (assoc ::error error)))})
 
-(defn- async-returns-error-ix
-  [stage ex]
-  {stage (fn [_ctx] (go ex))})
+(defn ->async
+  [itx]
+  "Convert the synchronous interceptor `itx` to the async equivalent"
+  (-> itx
+      (update :enter #(when % (fn [ctx] (async/go (% ctx)))))
+      (update :leave #(when % (fn [ctx] (async/go (% ctx)))))
+      (update :error #(when % (fn [ctx] (async/go (% ctx)))))))
 
 (deftest enqueue
   (testing "enqueues interceptors to an empty context"
@@ -74,98 +58,79 @@
           ctx (ix/clear-queue (ix/enqueue {} ixs))]
       (is (not (contains? ctx :lambda-toolshed.papillon/queue))))))
 
-(def empty-context {:lambda-toolshed.papillon/queue #?(:clj clojure.lang.PersistentQueue/EMPTY
-                                                       :cljs cljs.core/PersistentQueue.EMPTY)
-                    :lambda-toolshed.papillon/stack []})
-
-(defn ->async
-  [itx]
-  "Convert the synchronous interceptor `itx` to the async equivalent"
-  (-> itx
-      (update :enter #(when % (fn [ctx] (async/go (% ctx)))))
-      (update :leave #(when % (fn [ctx] (async/go (% ctx)))))
-      (update :error #(when % (fn [ctx] (async/go (% ctx)))))))
-
 (deftest allows-for-empty-chain-of-interceptors
-  (is (= empty-context (ix/execute {} []))))
+  (is (= {:lambda-toolshed.papillon/queue #?(:clj clojure.lang.PersistentQueue/EMPTY
+                                             :cljs cljs.core/PersistentQueue.EMPTY)
+          :lambda-toolshed.papillon/stack []}
+         (ix/execute {} []))))
 
 (deftest allows-for-interceptor-chain-of-only-enters
   (let [ixs [track-enter-ix]
-        res (ix/execute invocation-tracking-ctx ixs)]
+        res (ix/execute {} ixs)]
     (is (empty? (:lambda-toolshed.papillon/queue res)))
     (is (empty? (:lambda-toolshed.papillon/stack res)))
-    (is (= 1 (:enter-invocation-counts res)))
-    (is (= 0 (:leave-invocation-counts res)))
-    (is (= 0 (:error-invocation-counts res))))
+    (is (= {:enter 1} (:calls res))))
   (go-test
    (let [ixs [(->async track-enter-ix)]
-         [res _] (async/alts! [(ix/execute invocation-tracking-ctx ixs)
+         [res _] (async/alts! [(ix/execute {} ixs)
                                (async/timeout 10)])]
      (is (map? res))
      (is (empty? (:lambda-toolshed.papillon/queue res)))
      (is (empty? (:lambda-toolshed.papillon/stack res)))
-     (is (= 1 (:enter-invocation-counts res)))
-     (is (= 0 (:leave-invocation-counts res)))
-     (is (= 0 (:error-invocation-counts res))))))
+     (is (= {:enter 1} (:calls res))))))
 
 (deftest allows-for-interceptor-chain-of-only-leaves
   (let [ixs [track-leave-ix]
-        res (ix/execute invocation-tracking-ctx ixs)]
+        res (ix/execute {} ixs)]
     (is (empty? (:lambda-toolshed.papillon/queue res)))
     (is (empty? (:lambda-toolshed.papillon/stack res)))
-    (is (= 0 (:enter-invocation-counts res)))
-    (is (= 1 (:leave-invocation-counts res)))
-    (is (= 0 (:error-invocation-counts res))))
+    (is (= {:leave 1} (:calls res))))
   (go-test
    (let [ixs [(->async track-leave-ix)]
-         [res _] (async/alts! [(ix/execute invocation-tracking-ctx ixs)
+         [res _] (async/alts! [(ix/execute {} ixs)
                                (async/timeout 10)])]
      (is (map? res))
      (is (empty? (:lambda-toolshed.papillon/queue res)))
      (is (empty? (:lambda-toolshed.papillon/stack res)))
-     (is (= 0 (:enter-invocation-counts res)))
-     (is (= 1 (:leave-invocation-counts res)))
-     (is (= 0 (:error-invocation-counts res))))))
+     (is (= {:leave 1} (:calls res))))))
 
 (deftest allows-for-interceptor-chain-of-only-errors
   (let [ixs [track-error-ix]
-        res (ix/execute invocation-tracking-ctx ixs)]
+        res (ix/execute {} ixs)]
     (is (empty? (:lambda-toolshed.papillon/queue res)))
     (is (empty? (:lambda-toolshed.papillon/stack res)))
-    (is (= 0 (:enter-invocation-counts res)))
-    (is (= 0 (:leave-invocation-counts res)))
-    (is (= 0 (:error-invocation-counts res))))
+    (is (nil? (:calls res))))
   (go-test
    "Nothing to be done; chain can't start async processing with only error fns"))
 
 (deftest error-stage-is-never-invoked-if-no-error-has-been-thrown
-  (let [ixs (repeat 2 track-ix)
-        res (ix/execute invocation-tracking-ctx ixs)]
+  (let [ixs [track-all-ix]
+        res (ix/execute {} ixs)]
     (is (map? res))
     (is (empty? (:lambda-toolshed.papillon/queue res)))
     (is (empty? (:lambda-toolshed.papillon/stack res)))
-    (is (= 0 (:error-invocation-counts res))))
+    (is (= {:enter 1 :leave 1} (:calls res))))
   (go-test
-   (let [ixs (repeat 2 (->async track-ix))
-         [res _] (async/alts! [(ix/execute invocation-tracking-ctx ixs)
+   (let [ixs [(->async track-all-ix)]
+         [res _] (async/alts! [(ix/execute {} ixs)
                                (async/timeout 10)])]
      (is (map? res))
      (is (empty? (:lambda-toolshed.papillon/queue res)))
      (is (empty? (:lambda-toolshed.papillon/stack res)))
-     (is (= 0 (:error-invocation-counts res))))))
+     (is (= {:enter 1 :leave 1} (:calls res))))))
 
 (deftest exception-semantics-are-preserved
   (let [the-exception (ex-info "the exception" {})
-        ixs [(throws-ix :enter the-exception)]]
+        ixs [(throw-ix :enter the-exception)]]
     (is (thrown-with-msg?
          #?(:clj clojure.lang.ExceptionInfo :cljs ExceptionInfo)
          #"the exception"
-         (ix/execute invocation-tracking-ctx ixs))))
+         (ix/execute {} ixs))))
   (go-test
    (let [the-exception (ex-info "the exception" {})
          ixs [(->async {:enter identity}) ; transition to async
-              (throws-ix :enter the-exception)]
-         [res _] (async/alts! [(ix/execute invocation-tracking-ctx ixs)
+              (throw-ix :enter the-exception)]
+         [res _] (async/alts! [(ix/execute {} ixs)
                                (async/timeout 10)])]
      (is (= the-exception res)))))
 
@@ -174,95 +139,86 @@
         ixs [capture-ix
              track-error-ix
              track-error-ix
-             (merge (throws-ix :enter the-exception)
+             (merge (throw-ix :enter the-exception)
                     track-error-ix)]
-        res (ix/execute invocation-tracking-ctx ixs)]
+        res (ix/execute {} ixs)]
     (is (= the-exception (::error res)))
-    (is (= 3 (:error-invocation-counts res))))
+    (is (= {:error 3} (:calls res))))
   (go-test
    (let [the-exception (ex-info "the exception" {})
          ixs [(->async capture-ix)
               (->async track-error-ix)
               (->async track-error-ix)
               (->async track-error-ix)
-              (throws-ix :enter the-exception)]
-         [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
+              (throw-ix :enter the-exception)]
+         [res _] (alts! [(ix/execute {} ixs)
                          (async/timeout 10)])]
      (is (map? res))
      (is (= the-exception (::error res)))
-     (is (= 3 (:error-invocation-counts res))))))
+     (is (= {:error 3} (:calls res))))))
 
 (deftest error-chain-is-invoked-when-leave-throws-an-exception
   (let [the-exception (ex-info "the exception" {})
         ixs [capture-ix
-             (merge (throws-ix :leave the-exception)
+             (merge (throw-ix :leave the-exception)
                     track-error-ix)]
-        res (ix/execute invocation-tracking-ctx ixs)]
+        res (ix/execute {} ixs)]
     (is (= the-exception (::error res)))
-    (is (zero? (:error-invocation-counts res))))
+    (is (nil? (:calls res))))
   (go-test
    (let [the-exception (ex-info "the exception" {})
          ixs [(->async capture-ix)
-              (merge (throws-ix :leave the-exception)
+              (merge (throw-ix :leave the-exception)
                      track-error-ix)]
-         [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
+         [res _] (alts! [(ix/execute {} ixs)
                          (async/timeout 10)])]
      (is (map? res))
      (is (= the-exception (::error res)))
-     (is (zero? (:error-invocation-counts res))))))
+     (is (nil? (:calls res))))))
 
 (deftest leave-chain-is-resumed-when-error-processor-removes-error-key
   (let [the-exception (ex-info "the exception" {})
         ixs [(merge track-leave-ix track-error-ix)
              capture-ix
-             (merge (throws-ix :leave the-exception)
+             (merge (throw-ix :leave the-exception)
                     track-error-ix)]
-        res (ix/execute invocation-tracking-ctx ixs)]
+        res (ix/execute {} ixs)]
     (is (not (contains? res :lambda-toolshed.papillon/error)))
-    (is (zero? (:error-invocation-counts res)))
-    (is (= 1 (:leave-invocation-counts res))))
+    (is (= {:leave 1} (:calls res))))
   (go-test
    (let [the-exception (ex-info "the exception" {})
          ixs [(->async (merge track-leave-ix track-error-ix))
               (->async capture-ix)
-              (merge (throws-ix :leave the-exception)
+              (merge (throw-ix :leave the-exception)
                      track-error-ix)]
-         [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
+         [res _] (alts! [(ix/execute {} ixs)
                          (async/timeout 10)])]
      (is (map? res))
      (is (not (contains? res :lambda-toolshed.papillon/error)))
-     (is (zero? (:error-invocation-counts res)))
-     (is (= 1 (:leave-invocation-counts res))))))
+     (is (= {:leave 1} (:calls res))))))
 
 (deftest reduced-context-stops-enter-chain-processing
   (let [ixs [(merge track-enter-ix track-leave-ix)
              {:enter reduced}
              track-enter-ix]
-        res (ix/execute invocation-tracking-ctx ixs)]
-    (is (= 1 (:enter-invocation-counts res)))
-    (is (= 1 (:leave-invocation-counts res))))
+        res (ix/execute {} ixs)]
+    (is (= {:enter 1 :leave 1} (:calls res))))
   (go-test
    (let [ixs [(->async (merge track-enter-ix track-leave-ix))
               (->async {:enter reduced})
               (->async track-enter-ix)]
-         [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
+         [res _] (alts! [(ix/execute {} ixs)
                          (async/timeout 10)])]
      (is (map? res))
-     (is (= 1 (:enter-invocation-counts res)))
-     (is (= 1 (:leave-invocation-counts res))))))
+     (is (= {:enter 1 :leave 1} (:calls res))))))
 
-(do
-  #?(:cljs
-     (deftest allows-for-promise-return-values
-       (go-test
-        (let [ixs [{:enter (fn [ctx]
-                             (js/Promise.resolve
-                              (update-in ctx [(keyword (str (name :enter) "-invocation-counts"))] inc)))}]
-              [res _] (alts! [(ix/execute invocation-tracking-ctx ixs)
-                              (async/timeout 10)])]
-          (is (map? res))
-          (is (empty? (:lambda-toolshed.papillon/queue res)))
-          (is (empty? (:lambda-toolshed.papillon/stack res)))
-          (is (= 1 (:enter-invocation-counts res)))
-          (is (= 0 (:leave-invocation-counts res)))
-          (is (= 0 (:error-invocation-counts res))))))))
+#?(:cljs
+   (deftest allows-for-promise-return-values
+     (go-test
+      (let [ixs [{:enter (comp (fn [x] (js/Promise.resolve x)) (:enter track-enter-ix))}]
+            [res _] (alts! [(ix/execute {} ixs)
+                            (async/timeout 10)])]
+        (is (map? res))
+        (is (empty? (:lambda-toolshed.papillon/queue res)))
+        (is (empty? (:lambda-toolshed.papillon/stack res)))
+        (is (= {:enter 1} (:calls res)))))))

--- a/test/lambda_toolshed/test_utils.cljc
+++ b/test/lambda_toolshed/test_utils.cljc
@@ -1,5 +1,6 @@
 (ns lambda-toolshed.test-utils
   (:require [clojure.core.async :as async]
+            [clojure.core.async.impl.protocols :as impl]
             [clojure.test :as test]))
 
 (defmacro go-test
@@ -7,6 +8,31 @@
   [& body]
   (if (:ns &env)
     ;; In ClojureScript we execute the body as a test/async body inside a go block.
-    `(test/async done# (async/go (do ~@body) (done#)))
+    `(let [c# (async/promise-chan)
+           obj# (test/async done# (async/go (let [res# (do ~@body)] (async/>! c# res#)) (done#)))]
+       (reify
+         cljs.test/IAsyncTest
+         cljs.core/IFn
+         (~'-invoke [_# done2#] (obj# done2#) c#)))
     ;; In Clojure we block awaiting the completion of the async test block
     `(async/<!! (async/go (do ~@body)))))
+
+(defn runt-fn!
+  "`runt!` helper function"
+  [f]
+  (let [once-fixture-fn (clojure.test/join-fixtures (:clojure.test/once-fixtures (meta *ns*)))
+        each-fixture-fn (clojure.test/join-fixtures (:clojure.test/each-fixtures (meta *ns*)))]
+    (once-fixture-fn
+     (fn []
+       (each-fixture-fn
+        (fn []
+          #?(:clj (f)
+             :cljs (let [f (f)]
+                     (if (satisfies? cljs.test/IAsyncTest f)
+                       (f (fn done []))
+                       f)))))))))
+
+(defmacro runt!
+  "Run expression with fixtures"
+  [& body]
+  `(runt-fn! (fn [] ~@body)))


### PR DESCRIPTION
In addition to the sync/async semantics split, these additional features were introduced:

* Removed some superfluous channeling.
* Support naming of interceptors.
* Support interceptor tracing in context (using names where possible).
* Catch some nasty failure modes (especially channel closing without returning a context).
* Changed argument order for `execute` to move most-frequently-changing parameters last (and thus support `partial` execution).  This is the only realistic BC problem AFAICT.