### PR TITLE
Error checking

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src" "resources"]
  :deps {org.clojure/clojure {:mvn/version "1.10.3"}
-        org.clojure/clojurescript {:mvn/version "1.10.773"}
+        org.clojure/clojurescript {:mvn/version "1.11.60"}
         org.clojure/core.async {:mvn/version "1.3.618"}}
  :aliases {:build {:deps {io.github.seancorfield/build-clj
                           {:git/tag "v0.6.4" :git/sha "c21cfde"}}

--- a/examples/lambda_toolshed/papillon/examples/distributed_transaction.cljc
+++ b/examples/lambda_toolshed/papillon/examples/distributed_transaction.cljc
@@ -1,6 +1,6 @@
 (ns lambda-toolshed.papillon.examples.distributed-transaction
   (:require
-   [lambda-toolshed.papillon :as papillon :refer [into-queue]]
+   [lambda-toolshed.papillon :as papillon]
    [clojure.core.async :as async :refer [go put! <! >! chan]]
    [clojure.pprint :as pp]))
 
@@ -57,12 +57,10 @@
   interceptor to process, and removes the current interceptor
   from the stack to avoid dual attempts at cleanup."
   [ctx]
-  (let [stack (:lambda-toolshed.papillon/stack ctx)
-        current-as-queue (into-queue [(peek stack)])
-        new-stack (pop stack)]
+  (let [stack (:lambda-toolshed.papillon/stack ctx)]
     (-> ctx
-        (update-in [:lambda-toolshed.papillon/queue] #(into-queue current-as-queue %))
-        (assoc :lambda-toolshed.papillon/stack new-stack))))
+        (update :lambda-toolshed.papillon/queue #(into (empty %) (concat [(peek stack)] %)))
+        (update :lambda-toolshed.papillon/stack pop))))
 
 (defn- retry!
   "This handler will retry a request until it hits the retry limit.

--- a/examples/lambda_toolshed/papillon/examples/dynamic_tracing.cljc
+++ b/examples/lambda_toolshed/papillon/examples/dynamic_tracing.cljc
@@ -1,6 +1,6 @@
 (ns lambda-toolshed.papillon.examples.dynamic-tracing
   (:require
-   [lambda-toolshed.papillon :as papillon :refer [execute into-queue]]
+   [lambda-toolshed.papillon :as papillon :refer [execute]]
    [clojure.core.async :as async :refer [go <! >! chan]]
    clojure.pprint))
 
@@ -51,7 +51,7 @@
    :enter (fn [ctx]
             (if debug
               (let [queue (:lambda-toolshed.papillon/queue ctx)
-                    new-queue (into-queue (map wrap-with-timing queue))]
+                    new-queue (into (empty queue) (map wrap-with-timing) queue)]
                 (assoc ctx :lambda-toolshed.papillon/queue new-queue))
               ctx))})
 

--- a/examples/lambda_toolshed/papillon/examples/example.cljc
+++ b/examples/lambda_toolshed/papillon/examples/example.cljc
@@ -58,12 +58,11 @@
 ;; More complex debugging functionality, that shows that since the queue
 ;; and the stack are on the context, one can use that to their advantage
 (letfn [(describe-interceptor [ix] (or (:name ix) ix))
-        (prettify-interceptors [ixs] (map describe-interceptor ixs))
-        (prettify-queue [ixs] (into-queue (prettify-interceptors ixs)))
-        (prettify-keys [ctx & {:as opts}] (reduce (fn [accum [k f]] (update accum k f))  ctx opts))
+        (prettify [ixs] (into (empty ixs) (map describe-interceptor) ixs))
+        (prettify-keys [ctx & ks] (reduce (fn [accum k] (update accum k prettify)) ctx ks))
         (prettify-ctx [ctx] (prettify-keys ctx
-                                           :lambda-toolshed.papillon/queue prettify-queue
-                                           :lambda-toolshed.papillon/stack prettify-interceptors))
+                                           :lambda-toolshed.papillon/queue
+                                           :lambda-toolshed.papillon/stack))
         (make-debugger [stage] (fn [ctx]
                                  (clojure.pprint/pprint (str "Debug:: stage" stage))
                                  (clojure.pprint/pprint (prettify-ctx ctx))

--- a/examples/lambda_toolshed/papillon/examples/example.cljc
+++ b/examples/lambda_toolshed/papillon/examples/example.cljc
@@ -1,6 +1,6 @@
 (ns lambda-toolshed.papillon.examples.example
   (:require
-   [lambda-toolshed.papillon :as papillon :refer [enqueue execute into-queue]]
+   [lambda-toolshed.papillon :as papillon :refer [enqueue execute]]
    [clojure.core.async :as async :refer [go <! >! chan]]
    clojure.pprint))
 

--- a/src/lambda_toolshed/papillon.cljc
+++ b/src/lambda_toolshed/papillon.cljc
@@ -120,9 +120,7 @@
   (go-loop [ctx result]
     (if (satisfies? ReadPort ctx)
       (recur (<! ctx))
-      (if-let [error (::error ctx)]
-        error
-        ctx))))
+      (or (::error ctx) ctx))))
 
 (defn- namer [i ix]
   (if (:name ix)

--- a/src/lambda_toolshed/papillon.cljc
+++ b/src/lambda_toolshed/papillon.cljc
@@ -6,16 +6,9 @@
    #?@(:cljs ([goog.string :as gstring]
               goog.string.format))))
 
-(defn into-queue
-  ([xs]
-   (into-queue nil xs))
-  ([q xs]
-   ((fnil into #?(:clj clojure.lang.PersistentQueue/EMPTY
-                  :cljs cljs.core/PersistentQueue.EMPTY)) q xs)))
-
 (defn enqueue
   [ctx ixs]
-  (update-in ctx [::queue] into-queue ixs))
+  (update ctx ::queue into ixs))
 
 (defn- error?
   "Is the given value `x` an exception?"
@@ -114,9 +107,11 @@
   process the interceptor chain `ixs`."
   [ctx ixs]
   (-> ctx
-      (enqueue ixs)
+      (assoc ::queue #?(:clj clojure.lang.PersistentQueue/EMPTY
+                        :cljs cljs.core/PersistentQueue.EMPTY))
       (assoc ::stack [])
-      (vary-meta assoc :type ::ctx)))
+      (vary-meta assoc :type ::ctx)
+      (enqueue ixs)))
 
 (defn- present-sync
   [result]

--- a/src/lambda_toolshed/papillon.cljc
+++ b/src/lambda_toolshed/papillon.cljc
@@ -23,6 +23,12 @@
   #?(:clj (instance? Throwable x)
      :cljs (instance? js/Error x)))
 
+(defn clear-queue
+  "Empty the interceptor queue of the given context `ctx`, thus ensuring no
+  further processing of the `enter` chain is attempted."
+  [ctx]
+  (update ctx ::queue empty))
+
 (defn- async-catch
   "Takes a value from the channel `c` and checks if it is an error type value.
   If the result is an error type value then add that to the context `ctx` under
@@ -59,12 +65,6 @@
         (catch #?(:clj Throwable :cljs :default) err
           (assoc ctx ::error err)))
       ctx)))
-
-(defn clear-queue
-  "Remove the interceptor queue from the given context `ctx`, thus ensuring no
-  further processing of the `enter` chain is attempted."
-  [ctx]
-  (dissoc ctx ::queue))
 
 (defn- enter
   "Run the queued enter chain in the given context `ctx`.  If the

--- a/test/lambda_toolshed/papillon_test.cljc
+++ b/test/lambda_toolshed/papillon_test.cljc
@@ -36,10 +36,10 @@
       (is (= (::ix/queue ctx) (apply conj ixs ixs2))))))
 
 (deftest clear-queue
-  (testing "removes the queue key from the context"
+  (testing "clears the context's queue"
     (let [ixs [{:enter identity}]
           ctx (ix/clear-queue (ix/enqueue {} ixs))]
-      (is (not (contains? ctx ::ix/queue))))))
+      (is (empty? (ctx ::ix/queue))))))
 
 (deftest allows-for-empty-chain-of-interceptors
   (is (= {::ix/queue #?(:clj clojure.lang.PersistentQueue/EMPTY

--- a/test/lambda_toolshed/papillon_test.cljc
+++ b/test/lambda_toolshed/papillon_test.cljc
@@ -174,7 +174,7 @@
          [res _] (alts! [(ix/execute ixs {::ix/trace []})
                          (async/timeout 10)])]
      (is (map? res))
-     (is (= "Context channel was closed." (ex-message (res ::error))))
+     (is (= "Context was lost!" (ex-message (res ::error))))
      (is (= expected-log (::ix/trace res))))))
 
 (deftest leave-chain-is-resumed-when-error-processor-removes-error-key


### PR DESCRIPTION
Catch several sources of errors that manifest with the context being lost.  De-complect the how and when of context transitions.