### PR TITLE
Introduce Chrysalis protocol for async processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,23 +2,27 @@
 All notable changes to this project will be documented in this file. This change log follows the conventions of [keepachangelog.com](http://keepachangelog.com/).
 
 ## [Unreleased]
-### Changed
-- Add a new arity to `make-widget-async` to provide a different widget shape.
 
-## [0.1.1] - 2022-01-07
+### Added
+- A new protocol `Chrysalis` as the unifying result type for synchronous and asynchronous results.
+  - Add support for IDeref protocol as Chrysalis, allowing `Future` results to be synchronously awaited and turned back to synchronous execution flow.
+- New exception entry under the `::error` key when the context is lost during execution.
+
 ### Changed
-- Documentation on how to make the widgets.
+- Fully synchronous interceptor chain returns the result directly, or throws the value in the `::error` key.
+- Interceptor chain with at least one asynchronous interceptor return value in it now:
+  - returns the result wrapped in the asynchronous type of the outermost interceptor
+  - the wrapped result is now either
+    - the value under the `::error` key in the context, if present,
+    - or the final context otherwise
 
 ### Removed
-- `make-widget-sync` - we're all async, all the time.
+- Remove the direct dependency on `core.async`, a new namespace of `lambda-toolshed.papillon.async.core-async` has been included to support extending a `core.async` channel to be a `Chrysalis`.
+  - This should allow usage of Papillon in other target runtimes, e.g. `nbb`, that do not support `core.async`
 
-### Fixed
-- Fixed widget maker to keep working when daylight savings switches over.
-
-## 0.1.0 - 2022-01-07
+## 0.0.1-PREVIEW - 2022-01-20
 ### Added
-- Files from the new template.
-- Widget maker public API - `make-widget-sync`.
+- Initial Preview release
 
 [Unreleased]: https://github.com/lambda-toolshed/papillon/compare/0.1.1...HEAD
 [0.1.1]: https://github.com/lambda-toolshed/papillon/compare/0.1.0...0.1.1

--- a/examples/lambda_toolshed/papillon/examples/condition_system.cljc
+++ b/examples/lambda_toolshed/papillon/examples/condition_system.cljc
@@ -1,6 +1,7 @@
 (ns lambda-toolshed.papillon.examples.condition-system
   (:require
    [lambda-toolshed.papillon :as papillon :refer [execute]]
+   [lambda-toolshed.papillon.async.core-async]
    [clojure.core.async :as async :refer [go <!]]
    clojure.pprint))
 

--- a/examples/lambda_toolshed/papillon/examples/distributed_transaction.cljc
+++ b/examples/lambda_toolshed/papillon/examples/distributed_transaction.cljc
@@ -1,6 +1,7 @@
 (ns lambda-toolshed.papillon.examples.distributed-transaction
   (:require
    [lambda-toolshed.papillon :as papillon]
+   [lambda-toolshed.papillon.async.core-async]
    [clojure.core.async :as async :refer [go put! <! >! chan]]
    [clojure.pprint :as pp]))
 

--- a/examples/lambda_toolshed/papillon/examples/dynamic_tracing.cljc
+++ b/examples/lambda_toolshed/papillon/examples/dynamic_tracing.cljc
@@ -1,6 +1,7 @@
 (ns lambda-toolshed.papillon.examples.dynamic-tracing
   (:require
    [lambda-toolshed.papillon :as papillon :refer [execute]]
+   [lambda-toolshed.papillon.async.core-async]
    [clojure.core.async :as async :refer [go <! >! chan]]
    clojure.pprint))
 

--- a/examples/lambda_toolshed/papillon/examples/example.cljc
+++ b/examples/lambda_toolshed/papillon/examples/example.cljc
@@ -1,6 +1,7 @@
 (ns lambda-toolshed.papillon.examples.example
   (:require
    [lambda-toolshed.papillon :as papillon :refer [enqueue execute]]
+   [lambda-toolshed.papillon.async.core-async]
    [clojure.core.async :as async :refer [go <! >! chan]]
    clojure.pprint))
 
@@ -23,7 +24,7 @@
    :enter (fn [ctx]
             (update ctx :number #(* % 2)))})
 
-;; Run an interceptor chain with one interceptor in it that is synchronous
+;; Run an interceptor chain with two interceptors in it that is synchronous
 ;; and does not take an initial context to augment
 (let [c (execute [one-ix
                   double-number-ix])]
@@ -368,12 +369,12 @@
 
 ;; Interceptors can also manipulate the queue
 ;; this one uses `enqueue` to add more things to do
-(def ensure-even-with-tracing-ix
-  {:name :ensure-even-with-tracing-ix
+(def ensure-even-with-debugging-ix
+  {:name :ensure-even-with-debugging-ix
    :enter (fn [ctx]
             (if (even? (:number ctx))
               ctx
-              (enqueue ctx (with-tracing [double-number-ix async-square-number-ix async-square-number-ix]))))})
+              (enqueue ctx (with-debugging [double-number-ix async-square-number-ix async-square-number-ix]))))})
 
 ;; continues through the whole chain when the starting number is 3
 ;; note the traceing doesn't happen here as the interleaving was
@@ -383,7 +384,7 @@
 (go
   (let [c (execute (interleave (repeat debug-ix)
                                [async-square-number-ix
-                                ensure-even-with-tracing-ix])
+                                ensure-even-with-debugging-ix])
                    {:number 3})]
     (clojure.pprint/pprint (<! c))))
 
@@ -392,7 +393,7 @@
 (go
   (let [c (execute (interleave (repeat debug-ix)
                                [async-square-number-ix
-                                ensure-even-with-tracing-ix])
+                                ensure-even-with-debugging-ix])
                    {:number 2})]
     (clojure.pprint/pprint (<! c))))
 

--- a/src/lambda_toolshed/papillon/async.cljc
+++ b/src/lambda_toolshed/papillon/async.cljc
@@ -44,6 +44,13 @@
      (extend-type js/Promise
        Chrysalis
        (emerge [this handler]
-         (-> this
-             (.catch identity)
-             (.then handler))))))
+         (js/Promise. (fn [resolve reject]
+                        (let [wrapped-handler (fn [x]
+                                                (try
+                                                  (let [res (handler x)]
+                                                    (resolve res)
+                                                    res)
+                                                  (catch :default err
+                                                    (reject err)
+                                                    err)))]
+                          (.then this #(emerge % wrapped-handler) #(emerge % wrapped-handler)))))))))

--- a/src/lambda_toolshed/papillon/async.cljc
+++ b/src/lambda_toolshed/papillon/async.cljc
@@ -4,13 +4,14 @@
                [clojure.core.async.impl.protocols :refer [ReadPort]]
                [cljs.core.async.interop :as core.async.interop :refer [p->c]])))
 
+(defprotocol Chrysalis
+  (emerge [this handler]))
+
 #?(:cljs
    (do
      (extend-type js/Promise
-       ReadPort
-       (take! [this handler]
-         (->
-          this
-          p->c
-          (#(core.async/take 1 %))
-          (clojure.core.async.impl.protocols/take! handler))))))
+       Chrysalis
+       (emerge [this handler]
+         (-> this
+             (.catch identity)
+             (.then handler))))))

--- a/src/lambda_toolshed/papillon/async.cljc
+++ b/src/lambda_toolshed/papillon/async.cljc
@@ -25,7 +25,11 @@
    (extend-protocol Chrysalis
      clojure.lang.IDeref
      (emerge [this handler]
-       (handler @this))))
+       (let [p (promise)
+             wrapped-handler (fn wrapped-handler [x]
+                               (deliver p (handler x)))]
+         (emerge @this wrapped-handler)
+         @p))))
 
 #?(:clj
    (extend-protocol Chrysalis

--- a/src/lambda_toolshed/papillon/async/core_async.cljc
+++ b/src/lambda_toolshed/papillon/async/core_async.cljc
@@ -1,20 +1,23 @@
 (ns lambda-toolshed.papillon.async.core-async
   (:require
    #?(:cljs [cljs.core.async.impl.channels])
-   [clojure.core.async :refer [<! go-loop]]
+   [clojure.core.async :refer [<! chan go-loop put!]]
    [clojure.core.async.impl.protocols :refer [ReadPort]]
-   [lambda-toolshed.papillon.async :refer [Chrysalis]]))
+   [lambda-toolshed.papillon.async :refer [Chrysalis emerge]]))
 
 (extend-type
  #?(:clj  clojure.core.async.impl.protocols.Channel
     :cljs cljs.core.async.impl.channels/ManyToManyChannel)
   Chrysalis
   (emerge [this handler]
-    (go-loop [res this]
-      (let [x (<! res)]
-        (if (satisfies? ReadPort x)
-          (recur x)
-          (try
-            (handler x)
-            (catch #?(:clj Throwable :cljs :default) err
-              err)))))))
+    (let [c (chan 1)]
+      (go-loop [res this]
+        (let [x (<! res)]
+          (if (satisfies? ReadPort x)
+            (recur x)
+            (emerge x (fn [x]
+                        (put! c (try
+                                  (handler x)
+                                  (catch #?(:clj Throwable :cljs :default) err
+                                    err))))))))
+      c)))

--- a/src/lambda_toolshed/papillon/async/core_async.cljc
+++ b/src/lambda_toolshed/papillon/async/core_async.cljc
@@ -1,0 +1,17 @@
+(ns lambda-toolshed.papillon.async.core-async
+  (:require
+   #?(:cljs [cljs.core.async.impl.channels])
+   [clojure.core.async :refer [<! go-loop]]
+   [clojure.core.async.impl.protocols :refer [ReadPort]]
+   [lambda-toolshed.papillon.async :refer [Chrysalis]]))
+
+(extend-type
+ #?(:clj  clojure.core.async.impl.protocols.Channel
+    :cljs cljs.core.async.impl.channels/ManyToManyChannel)
+  Chrysalis
+  (emerge [this handler]
+    (go-loop [res this]
+      (let [x (<! res)]
+        (if (satisfies? ReadPort x)
+          (recur x)
+          (handler x))))))

--- a/src/lambda_toolshed/papillon/async/core_async.cljc
+++ b/src/lambda_toolshed/papillon/async/core_async.cljc
@@ -14,4 +14,7 @@
       (let [x (<! res)]
         (if (satisfies? ReadPort x)
           (recur x)
-          (handler x))))))
+          (try
+            (handler x)
+            (catch #?(:clj Throwable :cljs :default) err
+              err)))))))

--- a/src/lambda_toolshed/papillon/util.cljc
+++ b/src/lambda_toolshed/papillon/util.cljc
@@ -1,0 +1,7 @@
+(ns lambda-toolshed.papillon.util)
+
+(defn error?
+  "Is the given value `x` an exception?"
+  [x]
+  #?(:clj (instance? Throwable x)
+     :cljs (instance? js/Error x)))

--- a/test/lambda_toolshed/test_utils.cljc
+++ b/test/lambda_toolshed/test_utils.cljc
@@ -1,6 +1,5 @@
 (ns lambda-toolshed.test-utils
   (:require [clojure.core.async :as async]
-            [clojure.core.async.impl.protocols :as impl]
             [clojure.test :as test]))
 
 (defmacro go-test
@@ -20,8 +19,8 @@
 (defn runt-fn!
   "`runt!` helper function"
   [f]
-  (let [once-fixture-fn (clojure.test/join-fixtures (:clojure.test/once-fixtures (meta *ns*)))
-        each-fixture-fn (clojure.test/join-fixtures (:clojure.test/each-fixtures (meta *ns*)))]
+  (let [once-fixture-fn (test/join-fixtures (:clojure.test/once-fixtures (meta *ns*)))
+        each-fixture-fn (test/join-fixtures (:clojure.test/each-fixtures (meta *ns*)))]
     (once-fixture-fn
      (fn []
        (each-fixture-fn


### PR DESCRIPTION
Decouple dependence on core.async by introducing our own protocol to represent processing, while still allowing for core.async use if the client opts into using core.async by providing an optional namespace to include that allows a channel to implmement the Chrysalis protocol.

Also update examples to include the optional namespace so they can still work with core.async.