### PR TITLE
Exceptionally, perform a self-move on leave->error transition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased]
 ### Changed
 - The auto-naming of unnamed interceptors has changed to use the hash of the interceptor instead of its ordinal position in the initial queue.  Position is not easily defined for interceptors queued after the initial execution.
+- Transitions from the leave stage to the error stage will first consider the offending interceptor before consuming the stack.
 ### Added
 - The Chrysalis protocol is used by papillon to realize deferred contexts between interceptor transitions.
 - The execution of the interceptor chain can now be run asynchronously or synchronously.

--- a/test/lambda_toolshed/papillon_test.cljc
+++ b/test/lambda_toolshed/papillon_test.cljc
@@ -164,6 +164,7 @@
         expected-trace [[:ix-catch :enter]
                         [:ix-throw-on-leave :enter]
                         [:ix-throw-on-leave :leave]
+                        [:ix-throw-on-leave :error]
                         [:ix-catch :error]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
@@ -248,6 +249,7 @@
         expected-trace [[:ix-catch :enter]
                         [:ix-thrown-chrysalis :enter]
                         [:ix-thrown-chrysalis :leave]
+                        [:ix-thrown-chrysalis :error]
                         [:ix-catch :error]]]
     #?(:clj (testing "sync"
               (let [result (ix/execute ixs $ctx)]
@@ -269,6 +271,7 @@
                         [:ix-catch :enter]
                         [:ix-throw-on-leave :enter]
                         [:ix-throw-on-leave :leave]
+                        [:ix-throw-on-leave :error]
                         [:ix-catch :error]
                         [:ix :leave]]]
     (testing "sync"


### PR DESCRIPTION
This PR modifies the chain execution when transitioning from the `:leave` stage to the `:error` stage such that the offending ix is executed before the stack is consumed (on the `:error` stage, of course).

If the `:error` function of an ix throws, the stack is consumed and infinite loops are avoided.