### PR TITLE
Add support for :final stage & error-after-leave semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased]
 ### Changed
 - The auto-naming of unnamed interceptors has changed to use the hash of the interceptor instead of its ordinal position in the initial queue.  Position is not easily defined for interceptors queued after the initial execution.
-- Transitions from the leave stage to the error stage will first consider the offending interceptor before consuming the stack.
+- Transitions from the leave stage to the error stage will first consider the offending interceptor's `:error` stage  before consuming the stack.
+- The state of the stack used by papillon when working back out of the chain is now only updated when popping off the top of the stack to execute the `:final` stage.
 ### Added
 - The Chrysalis protocol is used by papillon to realize deferred contexts between interceptor transitions.
 - The execution of the interceptor chain can now be run asynchronously or synchronously.
 - If a var is queued (instead of an actual map interceptor), it will be dereferenced before being queued.
+- The optional `:final` stage has been added.
 
 [Unreleased]: https://github.com/lambda-toolshed/papillon/compare/0.1.1...HEAD
 [0.1.1]: https://github.com/lambda-toolshed/papillon/compare/0.1.0...0.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file. This change
 ## [Unreleased]
 ### Changed
 - The auto-naming of unnamed interceptors has changed to use the hash of the interceptor instead of its ordinal position in the initial queue.  Position is not easily defined for interceptors queued after the initial execution.
+- Transitions from the leave stage to the error stage will first consider the offending interceptor before consuming the stack.
 ### Added
 - The Chrysalis protocol is used by papillon to realize deferred contexts between interceptor transitions.
 - The execution of the interceptor chain can now be run asynchronously or synchronously.

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+ :deps {org.clojure/clojure {:mvn/version "1.12.0"}
         org.clojure/clojurescript {:mvn/version "1.11.132"}}
  :aliases {:build {:deps {io.github.seancorfield/build-clj
                           {:git/tag "v0.9.2" :git/sha "9c9f078"}}
@@ -10,7 +10,7 @@
                   :extra-deps {org.clojure/core.async {:mvn/version "1.6.681"}
                                org.clojure/test.check {:mvn/version "1.1.1"}}}
            :project/test-cljs {:main-opts ["-m" "cljs-test-runner.main"]
-                               :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.0"}}
+                               :extra-deps {olical/cljs-test-runner {:mvn/version "3.8.1"}}
                                :jvm-opts ["-DENVIRONMENT=test"]}
            :project/test-clj {:extra-deps {io.github.cognitect-labs/test-runner
                                            {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
@@ -19,7 +19,7 @@
                               :jvm-opts ["-DENVIRONMENT=test"]}
 
            ;; for interactive test running
-           :project/watch-test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.87.1366"}}
+           :project/watch-test {:extra-deps {lambdaisland/kaocha {:mvn/version "1.91.1392"}}
                                 :exec-fn kaocha.runner/exec-fn
                                 :exec-args {:watch? true
                                             :skip-meta :slow
@@ -48,10 +48,10 @@
                                   :main-opts  ["-m" "cljfmt.main" "check"]}
 
            :project/cljs-nrepl {:main-opts ["-m" "nrepl.cmdline" "--middleware" "[\"cider.piggieback/wrap-cljs-repl\"]"]
-                                :extra-deps  {nrepl/nrepl  {:mvn/version "1.1.0"}
+                                :extra-deps  {nrepl/nrepl  {:mvn/version "1.3.0"}
                                               cider/piggieback {:mvn/version "0.5.3"}}}
 
            :project/nrepl {:main-opts ["-m" "nrepl.cmdline" "--middleware" "[\"cider.nrepl/cider-middleware\"]"]
-                           :extra-deps {nrepl/nrepl {:mvn/version "1.1.0"}
-                                        cider/cider-nrepl {:mvn/version "0.45.0"}}
+                           :extra-deps {nrepl/nrepl {:mvn/version "1.3.0"}
+                                        cider/cider-nrepl {:mvn/version "0.50.2"}}
                            :jvm-opts ["-DENVIRONMENT=staging"]}}}

--- a/src/lambda_toolshed/papillon.cljc
+++ b/src/lambda_toolshed/papillon.cljc
@@ -101,8 +101,7 @@
   [ctx]
   (when-let [[ctx ix stage] (move ctx)]
     (let [tag [(identify ix) stage]
-          ctx (update ctx ::trace (fn [t] (when t
-                                            (if (= :final stage) t (conj t tag)))))
+          ctx (update ctx ::trace (fn [t] (when t (conj t tag))))
           f (or (ix stage) identity)
           obj (try (f ctx) (catch #?(:clj Throwable :cljs :default) e e))]
       [ctx obj tag])))

--- a/src/lambda_toolshed/papillon/completeable_future.clj
+++ b/src/lambda_toolshed/papillon/completeable_future.clj
@@ -1,0 +1,12 @@
+(ns lambda-toolshed.papillon.channel
+  (:require [lambda-toolshed.papillon.protocols :as protocols])
+  (:import (java.util.concurrent CompletableFuture)
+           (java.util.function Function)))
+
+(extend-protocol lambda-toolshed.papillon.protocols/Chrysalis
+  CompletableFuture
+  (emerge
+    ([this] (deref this))
+    ([this callback] (let [h-then (reify Function (apply [_ x] (callback x)))
+                           h-catch (reify Function (apply [_ e] (callback (ex-cause e))))]
+                       (.exceptionally (.thenApply this h-then) h-catch)))))

--- a/test/lambda_toolshed/papillon/channel_test.cljc
+++ b/test/lambda_toolshed/papillon/channel_test.cljc
@@ -34,7 +34,9 @@
         expected-trace [[:ix-chrysalis :enter]
                         [:ix :enter]
                         [:ix :leave]
-                        [:ix-chrysalis :leave]]]
+                        [:ix :final]
+                        [:ix-chrysalis :leave]
+                        [:ix-chrysalis :final]]]
     #?(:clj (testing "sync"
               (let [result (ix/execute ixs $ctx)]
                 (is (= expected-trace (::ix/trace result)))
@@ -55,7 +57,9 @@
         expected-trace [[::hello :enter]
                         [::world :enter]
                         [::world :leave]
-                        [::hello :leave]]]
+                        [::world :final]
+                        [::hello :leave]
+                        [::hello :final]]]
     (test-async done
                 (let [c (async/chan)
                       callback (partial async/put! c)]

--- a/test/lambda_toolshed/papillon_test.cljc
+++ b/test/lambda_toolshed/papillon_test.cljc
@@ -48,7 +48,7 @@
 
 (deftest baseline
   (let [ixs [ix-counter]
-        expected-trace [[:ix-counter :enter] [:ix-counter :leave]]]
+        expected-trace [[:ix-counter :enter] [:ix-counter :leave] [:ix-counter :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))
@@ -84,7 +84,7 @@
 
 (deftest allows-for-interceptor-chain-of-only-enters
   (let [ixs [{:name :ix :enter identity}]
-        expected-trace [[:ix :enter] [:ix :leave]]]
+        expected-trace [[:ix :enter] [:ix :leave] [:ix :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))
@@ -99,7 +99,7 @@
 
 (deftest allows-for-interceptor-chain-of-only-leaves
   (let [ixs [{:name :ix :leave identity}]
-        expected-trace [[:ix :enter] [:ix :leave]]]
+        expected-trace [[:ix :enter] [:ix :leave] [:ix :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))
@@ -114,7 +114,7 @@
 
 (deftest allows-for-interceptor-chain-of-only-errors
   (let [ixs [{:name :ix :error identity}]
-        expected-trace [[:ix :enter] [:ix :leave]]]
+        expected-trace [[:ix :enter] [:ix :leave] [:ix :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))
@@ -147,7 +147,9 @@
         expected-trace [[:ix-catch :enter]
                         [:ix-throw-on-enter :enter]
                         [:ix-throw-on-enter :error]
-                        [:ix-catch :error]]]
+                        [:ix-throw-on-enter :final]
+                        [:ix-catch :error]
+                        [:ix-catch :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))
@@ -166,7 +168,9 @@
                         [:ix-throw-on-leave :enter]
                         [:ix-throw-on-leave :leave]
                         [:ix-throw-on-leave :error]
-                        [:ix-catch :error]]]
+                        [:ix-throw-on-leave :final]
+                        [:ix-catch :error]
+                        [:ix-catch :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))
@@ -188,7 +192,9 @@
         expected-trace [[:ix-chrysalis :enter]
                         [:ix :enter]
                         [:ix :leave]
-                        [:ix-chrysalis :leave]]]
+                        [:ix :final]
+                        [:ix-chrysalis :leave]
+                        [:ix-chrysalis :final]]]
     #?(:clj (testing "sync"
               (let [result (ix/execute ixs $ctx)]
                 (is (= expected-trace (::ix/trace result)))
@@ -209,7 +215,9 @@
         expected-trace [[:ix-catch :enter]
                         [:ix-thrown-chrysalis :enter]
                         [:ix-thrown-chrysalis :error]
-                        [:ix-catch :error]]]
+                        [:ix-thrown-chrysalis :final]
+                        [:ix-catch :error]
+                        [:ix-catch :final]]]
     #?(:clj (testing "sync"
               (let [result (ix/execute ixs $ctx)]
                 (is (= expected-trace (::ix/trace result)))
@@ -229,7 +237,9 @@
         expected-trace [[:ix-catch :enter]
                         [:loser :enter]
                         [:loser :error]
-                        [:ix-catch :error]]]
+                        [:loser :final]
+                        [:ix-catch :error]
+                        [:ix-catch :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))
@@ -251,7 +261,9 @@
                         [:ix-thrown-chrysalis :enter]
                         [:ix-thrown-chrysalis :leave]
                         [:ix-thrown-chrysalis :error]
-                        [:ix-catch :error]]]
+                        [:ix-thrown-chrysalis :final]
+                        [:ix-catch :error]
+                        [:ix-catch :final]]]
     #?(:clj (testing "sync"
               (let [result (ix/execute ixs $ctx)]
                 (is (= expected-trace (::ix/trace result)))
@@ -273,8 +285,11 @@
                         [:ix-throw-on-leave :enter]
                         [:ix-throw-on-leave :leave]
                         [:ix-throw-on-leave :error]
+                        [:ix-throw-on-leave :final]
                         [:ix-catch :error]
-                        [:ix :leave]]]
+                        [:ix-catch :final]
+                        [:ix :leave]
+                        [:ix :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))
@@ -290,7 +305,8 @@
 (deftest reduced-context-stops-enter-chain-processing
   (let [ixs [{:name :reducer :enter reduced} ix]
         expected-trace [[:reducer :enter]
-                        [:reducer :leave]]]
+                        [:reducer :leave]
+                        [:reducer :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))
@@ -311,9 +327,13 @@
                         [:ix-throw-on-leave :enter]
                         [:ix-throw-on-leave :leave]
                         [:ix-throw-on-leave :error]
+                        [:ix-throw-on-leave :final]
                         [:ix-throw-on-error :error]
+                        [:ix-throw-on-error :final]
                         [:ix-catch :error]
-                        [:ix :leave]]]
+                        [:ix-catch :final]
+                        [:ix :leave]
+                        [:ix :final]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
         (is (= expected-trace (::ix/trace result)))

--- a/test/lambda_toolshed/papillon_test.cljc
+++ b/test/lambda_toolshed/papillon_test.cljc
@@ -164,6 +164,7 @@
         expected-trace [[:ix-catch :enter]
                         [:ix-throw-on-leave :enter]
                         [:ix-throw-on-leave :leave]
+                        [:ix-throw-on-leave :error]
                         [:ix-catch :error]]]
     (testing "sync"
       (let [result (ix/execute ixs $ctx)]
@@ -248,6 +249,7 @@
         expected-trace [[:ix-catch :enter]
                         [:ix-thrown-chrysalis :enter]
                         [:ix-thrown-chrysalis :leave]
+                        [:ix-thrown-chrysalis :error]
                         [:ix-catch :error]]]
     #?(:clj (testing "sync"
               (let [result (ix/execute ixs $ctx)]
@@ -269,6 +271,7 @@
                         [:ix-catch :enter]
                         [:ix-throw-on-leave :enter]
                         [:ix-throw-on-leave :leave]
+                        [:ix-throw-on-leave :error]
                         [:ix-catch :error]
                         [:ix :leave]]]
     (testing "sync"


### PR DESCRIPTION
Tests, doc updates/enhancements, changelog.  This includes all the functionality previously in #15 , plus the opt-in `:final` support and documentation/testing enhancements.

Also slipped in opt-in support for `java.util.concurrent.CompleteableFuture`.